### PR TITLE
Include non-standard ports in host header

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -458,7 +458,7 @@ before_loop(State=#state{keepalive=Keepalive}) ->
 	KeepaliveRef = erlang:send_after(Keepalive, self(), keepalive),
 	loop(State#state{keepalive_ref=KeepaliveRef}).
 
-loop(State=#state{parent=Parent, owner=Owner, host=Host,
+loop(State=#state{parent=Parent, owner=Owner, host=Host, port=Port,
 		retry=Retry, socket=Socket, transport=Transport,
 		protocol=Protocol, protocol_state=ProtoState}) ->
 	{OK, Closed, Error} = Transport:messages(),
@@ -494,11 +494,11 @@ loop(State=#state{parent=Parent, owner=Owner, host=Host,
 			before_loop(State#state{protocol_state=ProtoState2});
 		{request, Owner, StreamRef, Method, Path, Headers} ->
 			ProtoState2 = Protocol:request(ProtoState,
-				StreamRef, Method, Host, Path, Headers),
+				StreamRef, Method, Host, Port, Path, Headers),
 			loop(State#state{protocol_state=ProtoState2});
 		{request, Owner, StreamRef, Method, Path, Headers, Body} ->
 			ProtoState2 = Protocol:request(ProtoState,
-				StreamRef, Method, Host, Path, Headers, Body),
+				StreamRef, Method, Host, Port, Path, Headers, Body),
 			loop(State#state{protocol_state=ProtoState2});
 		{data, Owner, StreamRef, IsFin, Data} ->
 			ProtoState2 = Protocol:data(ProtoState,

--- a/src/gun_spdy.erl
+++ b/src/gun_spdy.erl
@@ -18,8 +18,8 @@
 -export([handle/2]).
 -export([close/1]).
 -export([keepalive/1]).
--export([request/6]).
 -export([request/7]).
+-export([request/8]).
 -export([data/4]).
 -export([cancel/2]).
 
@@ -191,7 +191,7 @@ keepalive(State=#spdy_state{socket=Socket, transport=Transport,
 
 %% @todo Allow overriding the host when doing requests.
 request(State=#spdy_state{socket=Socket, transport=Transport, zdef=Zdef,
-		stream_id=StreamID}, StreamRef, Method, Host, Path, Headers) ->
+		stream_id=StreamID}, StreamRef, Method, Host, _Port, Path, Headers) ->
 	Out = false =/= lists:keyfind(<<"content-type">>, 1, Headers),
 	Transport:send(Socket, cow_spdy:syn_stream(Zdef,
 		StreamID, 0, not Out, false, 0,
@@ -201,7 +201,7 @@ request(State=#spdy_state{socket=Socket, transport=Transport, zdef=Zdef,
 
 %% @todo Handle Body > 16MB. (split it out into many frames)
 request(State=#spdy_state{socket=Socket, transport=Transport, zdef=Zdef,
-		stream_id=StreamID}, StreamRef, Method, Host, Path, Headers, Body) ->
+		stream_id=StreamID}, StreamRef, Method, Host, _Port, Path, Headers, Body) ->
 	Headers2 = lists:keystore(<<"content-length">>, 1, Headers,
 		{<<"content-length">>, integer_to_list(iolist_size(Body))}),
 	Transport:send(Socket, [


### PR DESCRIPTION
As per RFC 2616, non-standard ports must be sent with the host name in
the host header as specified by the URI.

Previously, only the host name was sent; fixed.