### PR TITLE
Fix ws_upgrade to merge argument headers

### DIFF
--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -402,7 +402,7 @@ ws_upgrade(State=#http_state{socket=Socket, transport=Transport, out=head},
 		{<<"upgrade">>, <<"websocket">>},
 		{<<"sec-websocket-version">>, <<"13">>},
 		{<<"sec-websocket-key">>, Key}
-		|ExtHeaders
+		|Headers ++ ExtHeaders
 	],
 	IsSecure = Transport:secure(),
 	Headers3 = case lists:keymember(<<"host">>, 1, Headers) of


### PR DESCRIPTION
As mentioned at https://github.com/ninenines/gun/issues/63 , I merged `Headers` argument into `Headers2` to be able to set headers.