### PR TITLE
Use https instead of git for ranch and cowlib dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-	{cowlib, ".*", {git, "git://github.com/extend/cowlib.git", "1.3.0"}},
-	{ranch, ".*", {git, "git://github.com/extend/ranch.git", "master"}}
+	{cowlib, ".*", {git, "https://github.com/extend/cowlib.git", "1.3.0"}},
+	{ranch, ".*", {git, "https://github.com/extend/ranch.git", "master"}}
 ]}.


### PR DESCRIPTION
This is compatible with Cowboy and doesn't require authentication with
GitHub. Rebar and Mix do not automatically turn git:// into https://.

Fixes #82