### PR TITLE
Honor retry => 0 option even when host is down initially.

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -489,7 +489,7 @@ connect(State=#state{host=Host, port=Port, opts=Opts, transport=Transport=ranch_
 			end,
 			up(State, Socket, Protocol, ProtoOptsKey);
 		{error, _} ->
-			retry(State, Retries - 1)
+			retry(State, erlang:max(0, Retries - 1))
 	end;
 connect(State=#state{host=Host, port=Port, opts=Opts, transport=Transport}, Retries) ->
 	TransportOpts = [binary, {active, false}
@@ -502,7 +502,7 @@ connect(State=#state{host=Host, port=Port, opts=Opts, transport=Transport}, Retr
 			end,
 			up(State, Socket, Protocol, ProtoOptsKey);
 		{error, _} ->
-			retry(State, Retries - 1)
+			retry(State, erlang:max(0, Retries - 1))
 	end.
 
 up(State=#state{owner=Owner, opts=Opts, transport=Transport}, Socket, Protocol, ProtoOptsKey) ->


### PR DESCRIPTION
Previously when starting a gun connection when the host is down the
connection would never give up retrying to connect if `retry`
was set to 0.
