### PR TITLE
Fix badarg in http/2 ping generation

### DIFF
--- a/src/gun_http2.erl
+++ b/src/gun_http2.erl
@@ -197,7 +197,7 @@ close_streams(Owner, [#stream{ref=StreamRef}|Tail]) ->
 	close_streams(Owner, Tail).
 
 keepalive(State=#http2_state{socket=Socket, transport=Transport}) ->
-	Transport:send(Socket, cow_http2:ping(<< 0:64 >>)),
+	Transport:send(Socket, cow_http2:ping(0)),
 	State.
 
 %% @todo Shouldn't always be HTTPS scheme. We need to properly keep track of it.


### PR DESCRIPTION
cow_http2:ping/1 wants an integer, not a binary.

Originally I patched cow_lib to take a binary (ninenines/cowlib#38), but as @essen pointed out, parsing produces an integer, so instead, I've changed gun to send an integer.