### PR TITLE
Ignore errors from Transport:setopts/2

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -666,7 +666,7 @@ loop(State=#state{parent=Parent, owner=Owner, host=Host, port=Port, opts=Opts,
 ws_loop(State=#state{parent=Parent, owner=Owner, socket=Socket,
 		transport=Transport, protocol=Protocol, protocol_state=ProtoState}) ->
 	{OK, Closed, Error} = Transport:messages(),
-	ok = Transport:setopts(Socket, [{active, once}]),
+	Transport:setopts(Socket, [{active, once}]),
 	receive
 		{OK, Socket, Data} ->
 			case Protocol:handle(Data, ProtoState) of


### PR DESCRIPTION
`Transport:setopts/2` can return an error after the socket has been closed. We should ignore it.