### PR TITLE
Update links in README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -25,5 +25,4 @@ http://www.leofs.org[LeoFS Cloud Storage].
 == Support
 
 * Official IRC Channel: #ninenines on irc.freenode.net
-* http://lists.ninenines.eu[Mailing Lists]
-* http://ninenines.eu/support[Commercial Support]
+* https://ninenines.eu/services/[Commercial Support]


### PR DESCRIPTION
Mailing list was archived on August 29, 2016: https://ninenines.eu/archives/extend/

http://ninenines.eu/support is now a redirect.