### PR TITLE
Support for HTTP over Unix domain sockets

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -133,26 +133,18 @@ open(Host, Port) ->
 -spec open(inet:hostname(), inet:port_number(), opts())
 	-> {ok, pid()} | {error, any()}.
 open(Host, Port, Opts) when is_list(Host); is_atom(Host) ->
-	case check_options(maps:to_list(Opts)) of
-		ok ->
-			case supervisor:start_child(gun_sup, [self(), Host, Port, Opts]) of
-				OK = {ok, ServerPid} ->
-					consider_tracing(ServerPid, Opts),
-					OK;
-				StartError ->
-					StartError
-			end;
-		CheckError ->
-			CheckError
-	end.
+    open_(Host, Port, Opts).
 
 -spec open_unix(Path::string(), opts())
     -> {ok, pid()} | {error, any()}.
 open_unix(SocketPath, Opts) ->
     Host = {local, SocketPath},
     Port = 0,
-    case check_options(maps:to_list(Opts)) of
-        ok ->
+    open_(Host, Port, Opts).
+
+open_(Host, Port, Opts) ->
+	case check_options(maps:to_list(Opts)) of
+		ok ->
 			case supervisor:start_child(gun_sup, [self(), Host, Port, Opts]) of
 				OK = {ok, ServerPid} ->
 					consider_tracing(ServerPid, Opts),

--- a/src/gun.erl
+++ b/src/gun.erl
@@ -133,16 +133,14 @@ open(Host, Port) ->
 -spec open(inet:hostname(), inet:port_number(), opts())
 	-> {ok, pid()} | {error, any()}.
 open(Host, Port, Opts) when is_list(Host); is_atom(Host) ->
-    open_(Host, Port, Opts).
+    do_open(Host, Port, Opts).
 
 -spec open_unix(Path::string(), opts())
     -> {ok, pid()} | {error, any()}.
 open_unix(SocketPath, Opts) ->
-    Host = {local, SocketPath},
-    Port = 0,
-    open_(Host, Port, Opts).
+    do_open({local, SocketPath}, 0, Opts).
 
-open_(Host, Port, Opts) ->
+do_open(Host, Port, Opts) ->
 	case check_options(maps:to_list(Opts)) of
 		ok ->
 			case supervisor:start_child(gun_sup, [self(), Host, Port, Opts]) of

--- a/test/gun_SUITE.erl
+++ b/test/gun_SUITE.erl
@@ -15,7 +15,7 @@
 -module(gun_SUITE).
 -compile(export_all).
 
--import(ct_helper, [doc/1, config/2]).
+-import(ct_helper, [doc/1]).
 
 all() ->
 	ct_helper:all(?MODULE).
@@ -203,9 +203,18 @@ transform_header_name(_) ->
 	ok.
 
 unix_socket_connect(_) ->
+    case os:type() of
+        {win32, _} ->
+            doc("Unix Domain Sockets are not available on Windows.");
+        _ ->
+            do_unix_socket_connect()
+    end.
+
+do_unix_socket_connect() ->
     doc("Ensure we can send data via a unix domain socket."),
-    %% TODO This needs to be a CT-contained directory, not hard-coded.
-    SocketPath = "/tmp/gun.sock",
+    DataDir = "/tmp/gun",
+    SocketPath = filename:join(DataDir, "gun.sock"),
+    ok = filelib:ensure_dir(SocketPath),
     _ = file:delete(SocketPath),
     TCPOpts = [{ifaddr, {local, SocketPath}},
                binary, {nodelay, true}, {active, false},


### PR DESCRIPTION
As mentioned in #134 it's not that easy to use `gun` to make HTTP requests over a unix domain socket, but this branch aims to add that support. Please let me know if this approach is not one you would take and we can rework it.

I'd also like to find out how you would like to see this tested.

TODO:
 - [x] Confirm approach with @essen 
 - [x] Add explicit test cases for unix sockets
 - [x] Use a better `SocketPath` for test case