### PR TITLE
Fix! handle domain socket host for http2 authority header

### DIFF
--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -281,6 +281,7 @@ keepalive(State) ->
 request(State=#http_state{socket=Socket, transport=Transport, version=Version,
 		out=head}, StreamRef, ReplyTo, Method, Host, Port, Path, Headers) ->
 	Host2 = case Host of
+		{local, _SocketPath} -> <<>>;
 		Tuple when is_tuple(Tuple) -> inet:ntoa(Tuple);
 		_ -> Host
 	end,
@@ -304,6 +305,7 @@ request(State=#http_state{socket=Socket, transport=Transport, version=Version,
 request(State=#http_state{socket=Socket, transport=Transport, version=Version,
 		out=head}, StreamRef, ReplyTo, Method, Host, Port, Path, Headers, Body) ->
 	Host2 = case Host of
+		{local, _SocketPath} -> <<>>;
 		Tuple when is_tuple(Tuple) -> inet:ntoa(Tuple);
 		_ -> Host
 	end,

--- a/src/gun_http2.erl
+++ b/src/gun_http2.erl
@@ -352,6 +352,7 @@ request(State0=#http2_state{socket=Socket, transport=Transport, encode_state=Enc
 
 prepare_headers(EncodeState, Transport, Method, Host0, Port, Path, Headers0) ->
 	Host2 = case Host0 of
+		{local, _SocketPath} -> <<>>;
 		Tuple when is_tuple(Tuple) -> inet:ntoa(Tuple);
 		_ -> Host0
 	end,


### PR DESCRIPTION
unix domain socket tuple matched as a IP and called `inet:ntoa`.