### PR TITLE
Resolved missing function clause for '{gun_http2,frame,[{headers,1,no…

### DIFF
--- a/src/gun_http2.erl
+++ b/src/gun_http2.erl
@@ -143,6 +143,10 @@ frame({data, StreamID, IsFin, Data}, State0=#http2_state{remote_window=ConnWindo
 				'DATA frame received for a closed or non-existent stream. (RFC7540 6.1)'})
 	end;
 %% Single HEADERS frame headers block.
+frame({headers,StreamID, IsFin, head_fin, shared, HeaderBlock},
+		State=#http2_state{decode_state=DecodeState0, content_handlers=Handlers0}) ->
+	frame({headers, StreamID, IsFin, head_fin, HeaderBlock},
+		State=#http2_state{decode_state=DecodeState0, content_handlers=Handlers0});
 frame({headers, StreamID, IsFin, head_fin, HeaderBlock},
 		State=#http2_state{decode_state=DecodeState0, content_handlers=Handlers0}) ->
 	case get_stream_by_id(StreamID, State) of


### PR DESCRIPTION
Resolved missing function clause for '{gun_http2,frame,[{headers,1,nofin,head_fin,shared,...'. Gun didn't handle the 'shared' atom from a given parse return. While using gun for http2 requests, i encountered the following exception:

    exception exit: {{function_clause,[{gun_http2,frame,[{headers,1,nofin,head_fin,shared,0,16,<<SOME DATA>>},{http2_state,<0.1344.0>,{sslsocket,{gen_tcp,#Port<0.22879>,tls_connection,undefined},<0.1347.0>},gun_tls,#{},[gun_data_h],<<>>,#{initial_window_size => 65535,max_frame_size => 16384},#{initial_window_size => 2147483647,max_concurrent_streams => 100,max_header_list_size => 40960},2147483647,65535,[{stream,1,#Ref<0.0.4.745>,<0.1344.0>,fin,2147483647,{[],[]},0,undefined,nofin,65535,undefined}],3,{state,0,4096,4096,[]},{state,767,4096,4096,[{640,{<<"authorization">>,<<"Bearer XXXXXXXX>>}},{58,{<<":path">>,<<"/v20160207/directives">>}},{69,{<<":authority">>,<<"avs-alexa-na.amazon.com:443">>}}]}}],[{file,"/Users/user/projects/tavs/_build/default/lib/gun/src/gun_http2.erl"},{line,131}]},{gun_http2,parse,2,[{file,"/Users/user/projects/tavs/_build/default/lib/gun/src/gun_http2.erl"},{line,118}]},

Adding the guard resolved the issue.