### PR TITLE
Update `ws_opts` type

### DIFF
--- a/doc/src/guide/websocket.asciidoc
+++ b/doc/src/guide/websocket.asciidoc
@@ -40,6 +40,21 @@ You can pass the Websocket options as part of the `gun:open/2,3`
 call when opening the connection, or using the `gun:ws_upgrade/4`.
 The fourth argument is those same options.
 
+When the `sec-websocket-protocol` was specified in the `gun:ws_upgrade/3,4`
+and the server replies with the `sec-websocket-protocol` header,
+gun will try to find the `handler` module for `protocol` in the Websocket options.
+The upgrade fails if the `handler` is not found on `protocols` list.
+
+.Upgrade to Websocket, request a protocol and define handler for the protocol
+[source,erlang]
+----
+gun:ws_upgrade(ConnPid, "/websocket",
+               [{<<"sec-websocket-protocol">>, <<"xmpp">>}],
+               #{protocols => [{<<"xmpp">>, gun_ws_h}]}).
+----
+
+Currently, the only possible handler module is the default `gun_ws_h`.
+
 When the upgrade succeeds, a `gun_upgrade` message is sent.
 If the server does not understand Websocket or refused the
 upgrade, a `gun_response` message is sent. If Gun couldn't

--- a/doc/src/manual/gun.asciidoc
+++ b/doc/src/manual/gun.asciidoc
@@ -287,7 +287,8 @@ The pid of the process that will receive the response messages.
 [source,erlang]
 ----
 ws_opts() :: #{
-    compress => boolean()
+    compress  => boolean(),
+    protocols => [{binary(), module()}]
 }
 ----
 
@@ -300,6 +301,12 @@ compress => boolean()::
 Whether to enable permessage-deflate compression. This does
 not guarantee that compression will be used as it is the
 server that ultimately decides. Defaults to false.
+
+protocols => [{binary(), module()}]::
+
+What handler should be used for the specified Websocket `protocol`
+passed in the `sec-websocket-protocol` header.
+Currently, the only possible handler module is the default `gun_ws_h`.
 
 // @todo Document default_protocol, protocols and user_opts.
 

--- a/src/gun.erl
+++ b/src/gun.erl
@@ -156,7 +156,8 @@
 
 %% @todo keepalive
 -type ws_opts() :: #{
-	compress => boolean()
+	compress => boolean(),
+	protocols => [{binary(), module()}]
 }.
 -export_type([ws_opts/0]).
 


### PR DESCRIPTION
This PR adds the optional `protocols` key to `ws_opts` type and updates relevant parts of the documentation.

It also fixes #171 