### PR TITLE
Fix invalid stream reference in `gun_data` message for rejected websocket upgrade

### DIFF
--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -265,7 +265,7 @@ handle_head(Data, State=#http_state{socket=Socket, version=ClientVersion,
 					case IsFin of
 						fin -> undefined;
 						nofin ->
-							gun_content_handler:init(ReplyTo, StreamRef,
+							gun_content_handler:init(ReplyTo, stream_ref(StreamRef),
 								Status, Headers, Handlers0)
 					end
 			end,

--- a/test/handlers/ws_reject.erl
+++ b/test/handlers/ws_reject.erl
@@ -1,0 +1,6 @@
+-module(ws_reject).
+
+-export([init/2]).
+
+init(Req0, Env) ->
+    {ok, cowboy_req:reply(400, #{}, <<"Upgrade rejected">>, Req0), Env}.


### PR DESCRIPTION
When a server rejects a websocket upgrade request and sends a response body, gun doesn't strip the stream reference (set to `{websocket, ...}`) in the `gun_data` message. This breaks matching the `StreamRef` value in these messages.

I added a unit test for this case (it seems that the Autobahn suite doesn't verify it).