### PR TITLE
Fix Message Parsing Robustness of CRLF vs LF

### DIFF
--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -102,7 +102,7 @@ handle(_, #http_state{streams=[]}) ->
 %% Wait for the full response headers before trying to parse them.
 handle(Data, State=#http_state{in=head, buffer=Buffer}) ->
 	Data2 = << Buffer/binary, Data/binary >>,
-	case binary:match(Data2, <<"\r\n\r\n">>) of
+	case binary:match(Data2, [ <<"\n\n">>,<<"\r\n\r\n">>]) of
 		nomatch -> {state, State#http_state{buffer=Data2}};
 		{_, _} -> handle_head(Data2, State#http_state{buffer= <<>>})
 	end;


### PR DESCRIPTION
RFC7230 Section 3.5 Message Parsing Robustness contains:
   Although the line terminator for the start-line and header fields is
   the sequence CRLF, a recipient MAY recognize a single LF as a line
   terminator and ignore any preceding CR.

Minimal code change to allow for broken HTTP/1.1 implementations.

Also requires https://github.com/ninenines/cowlib/pull/74 to work properly.