### PR TITLE
Remove explicit call to dbg:start/0

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -276,7 +276,6 @@ check_options([Opt|_]) ->
 	{error, {options, Opt}}.
 
 consider_tracing(ServerPid, #{trace := true}) ->
-	dbg:start(),
 	dbg:tracer(),
 	dbg:tpl(gun, [{'_', [], [{return_trace}]}]),
 	dbg:tpl(gun_http, [{'_', [], [{return_trace}]}]),


### PR DESCRIPTION
This fixes a bug in `gun` when trying to open 2 connections with tracing enabled.

You can recreate it like so:

    > application:ensure_all_started(gun).
    > gun:open("localhost", 80, #{trace => true}).
    > gun:open("localhost", 80, #{trace => true}).

The second call fails with a cause clause exception.

You'll observe the same exception by:

    > dbg:start().
    > dbg:start().

Ultimately, this may be a bug in OTP, but since `dbg:start/0` is undocumented I'm inclined to give it the benefit of the doubt. Regardless, since the [documentation](http://erlang.org/doc/man/dbg.html) clearly states that calling `dbg:tracer/0` is the proper way to start the default tracer message receiver, I argue that calling `dbg:start/0` is a bug in `gun`.
