### PR TITLE
host header in Ws upgrade fixed

### DIFF
--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -606,12 +606,9 @@ ws_upgrade(State=#http_state{socket=Socket, transport=Transport, owner=Owner, ou
 		{<<"sec-websocket-key">>, Key}
 		|Headers2
 	],
-	IsSecure = Transport =:= gun_tls,
 	Headers = case lists:keymember(<<"host">>, 1, Headers0) of
 		true -> Headers3;
-		false when Port =:= 80, not IsSecure -> [{<<"host">>, Host}|Headers3];
-		false when Port =:= 443, IsSecure -> [{<<"host">>, Host}|Headers3];
-		false -> [{<<"host">>, [Host, $:, integer_to_binary(Port)]}|Headers3]
+		false -> [{<<"host">>, host_header(Transport, Host, Port)}|Headers3]
 	end,
 	Transport:send(Socket, cow_http:request(<<"GET">>, Path, 'HTTP/1.1', Headers)),
 	new_stream(State#http_state{connection=keepalive, out=head},


### PR DESCRIPTION
used already_implemented host_header/3 func, when adding host header in ws upgrade,
without it ws upgrade failed if Host was of  ip4_address() type: {0..255, 0..255, 0..255, 0..255}