### PR TITLE
Replace non-existant types

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -116,7 +116,7 @@
 	supervise       => boolean(),
 	trace           => boolean(),
 	transport       => tcp | tls | ssl,
-	transport_opts  => [gen_tcp:connect_option()] | [ssl:connect_option()],
+	transport_opts  => [gen_tcp:connect_option()] | [ssl:tls_client_option()],
 	ws_opts         => ws_opts()
 }.
 -export_type([opts/0]).
@@ -130,7 +130,7 @@
 	protocol => http | http2, %% @todo Remove in Gun 2.0.
 	protocols => [http | http2],
 	transport => tcp | tls,
-	tls_opts => [ssl:connect_option()],
+	tls_opts => [ssl:tls_client_option()],
 	tls_handshake_timeout => timeout()
 }.
 -export_type([connect_destination/0]).


### PR DESCRIPTION
There is no such type as `ssl:connect_option` I've replaced it with `ssl:tls_client_option`. You can check [this](http://erlang.org/doc/man/ssl.html#type-server_option) for reference.

This fixes `unknown type` warning from dialyzer.