### PR TITLE
fix rebar3 dependency specification

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-{cowlib,".*",{git,"https://github.com/ninenines/cowlib","2.9.0"}}
+{cowlib,".*",{git,"https://github.com/ninenines/cowlib",{tag,"2.9.0"}}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.


### PR DESCRIPTION
Rebar3 emits a warning for "raw" git dependency versions, and expects a
tuple indicating what the version actually is (a branch, tag or ref).

This warning propagates to any software directly or indirectly using
Gun.