### PR TITLE
fix rebar3 dependency specification

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -5491,7 +5491,7 @@ define compat_rebar_config
 $(call comma_list,$(foreach d,$(DEPS),\
 	$(if $(filter hex,$(call dep_fetch,$d)),\
 		{$(call dep_name,$d)$(comma)"$(call dep_repo,$d)"},\
-		{$(call dep_name,$d)$(comma)".*"$(comma){git,"$(call dep_repo,$d)"$(comma)"$(call dep_commit,$d)"}})))
+		{$(call dep_name,$d)$(comma)".*"$(comma){git,"$(call dep_repo,$d)"$(comma){ref,"$(call dep_commit,$d)"}}})))
 ]}.
 {erl_opts, $(call compat_erlc_opts_to_list,$(ERLC_OPTS))}.
 endef

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-{cowlib,".*",{git,"https://github.com/ninenines/cowlib","2.9.0"}}
+{cowlib,".*",{git,"https://github.com/ninenines/cowlib",{ref,"2.9.0"}}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.


### PR DESCRIPTION
Rebar3 emits a warning for "raw" git dependency versions, and expects a
tuple indicating what the version actually is (a branch, tag or ref).

This warning propagates to any software directly or indirectly using
Gun.