### PR TITLE
Enabling h2specd_SUITE.erl again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ $(H2SPECD):
 	$(gen_verbose) mkdir -p $(GOPATH)/src/github.com/summerwind
 	-$(verbose) git clone --depth 1 https://github.com/summerwind/h2spec $(dir $(H2SPECD))
 	-$(verbose) $(MAKE) -C $(dir $(H2SPECD)) build MAKEFLAGS=
-	-$(verbose) go build -o $(H2SPECD) $(dir $(H2SPECD))/cmd/h2spec/h2specd.go
+	-$(verbose) cd $(dir $(H2SPECD)) && go build cmd/h2specd/h2specd.go
 
 # Public suffix module generator.
 # https://publicsuffix.org/list/

--- a/test/h2specd_SUITE.erl
+++ b/test/h2specd_SUITE.erl
@@ -97,7 +97,8 @@ run_tests([Port|Tail]) ->
 	try
 		{ok, Conn} = gun:open("127.0.0.1", Port, #{
 			protocols => [http2],
-			retry => 0
+			retry => 0,
+			tcp_opts => [{nodelay, true}]
 		}),
 		MRef = monitor(process, Conn),
 		{ok, http2} = gun:await_up(Conn),


### PR DESCRIPTION
The main source file for the test tool h2specd was moved a time ago, so this PR make sure we use correct path when building it.
The h2spec project also uses `go modules` which now is used when building.

The change has been verified (build and passing of h2specd_SUITE) in a Github Action setup that uses a test matrix, consisting of all major versions of Go from v1.11 (2018) to latest 1.15.