### PR TITLE
Include content_handlers in opts

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -184,6 +184,7 @@
 
 -type http_opts() :: #{
 	closing_timeout => timeout(),
+	content_handlers => gun_content_handler:opt(),
 	flow => pos_integer(),
 	keepalive => timeout(),
 	transform_header_name => fun((binary()) -> binary()),
@@ -193,6 +194,7 @@
 
 -type http2_opts() :: #{
 	closing_timeout => timeout(),
+	content_handlers => gun_content_handler:opt(),
 	flow => pos_integer(),
 	keepalive => timeout(),
 


### PR DESCRIPTION
This fixes a dialyzer issue when using the gun and setting the `content_handlers` option.