### PR TITLE
Normalize headers in ws_upgrade

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -868,7 +868,7 @@ ws_upgrade(ServerPid, Path) ->
 -spec ws_upgrade(pid(), iodata(), req_headers()) -> reference().
 ws_upgrade(ServerPid, Path, Headers) ->
 	StreamRef = make_ref(),
-	gen_statem:cast(ServerPid, {ws_upgrade, self(), StreamRef, Path, Headers}),
+	gen_statem:cast(ServerPid, {ws_upgrade, self(), StreamRef, Path, normalize_headers(Headers)}),
 	StreamRef.
 
 -spec ws_upgrade(pid(), iodata(), req_headers(), ws_opts()) -> reference().
@@ -876,7 +876,7 @@ ws_upgrade(ServerPid, Path, Headers, Opts) ->
 	ok = gun_ws:check_options(Opts),
 	StreamRef = make_ref(),
 	ReplyTo = maps:get(reply_to, Opts, self()),
-	gen_statem:cast(ServerPid, {ws_upgrade, ReplyTo, StreamRef, Path, Headers, Opts}),
+	gen_statem:cast(ServerPid, {ws_upgrade, ReplyTo, StreamRef, Path, normalize_headers(Headers), Opts}),
 	StreamRef.
 
 %% @todo ws_send/2 will need to be deprecated in favor of a variant with StreamRef.

--- a/test/ws_SUITE.erl
+++ b/test/ws_SUITE.erl
@@ -70,6 +70,17 @@ error_http10_upgrade(Config) ->
 		error(timeout)
 	end.
 
+headers_normalized_upgrade(Config) ->
+	doc("Headers passed to ws_upgrade are normalized before being used."),
+	{ok, ConnPid} = gun:open("localhost", config(port, Config)),
+	{ok, _} = gun:await_up(ConnPid),
+	StreamRef = gun:ws_upgrade(ConnPid, "/", #{
+		atom_header_name => <<"value">>,
+		"string_header_name" => <<"value">>
+	}),
+	{upgrade, [<<"websocket">>], _} = gun:await(ConnPid, StreamRef),
+	gun:close(ConnPid).
+
 error_http_request(Config) ->
 	doc("Ensure that requests are rejected while using Websocket."),
 	{ok, ConnPid} = gun:open("localhost", config(port, Config)),


### PR DESCRIPTION
In the documentation headers passed to ws_upgrade are typed as
gun:req_headers(), however if a map of headers is passed (which is
allowed by the type), the gun process will crash when trying to operate
on it as if it were a list.