### PR TITLE
Add http2.remote_settings to gun:info map

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -423,7 +423,7 @@ info(ServerPid) ->
 		origin_port=OriginPort,
 		intermediaries=Intermediaries,
 		cookie_store=CookieStore
-	}} = sys:get_state(ServerPid),
+	} = State } = sys:get_state(ServerPid),
 	Info0 = #{
 		owner => Owner,
 		socket => Socket,
@@ -454,6 +454,12 @@ info(ServerPid) ->
 	end,
 	case Protocol of
 		undefined -> Info;
+		gun_http2 ->
+			RemoteSettings = gun_http2:get_remote_settings(State#state.protocol_state),
+			Info#{
+				protocol => Protocol:name(),
+				http2 => #{remote_settings => RemoteSettings}
+			};
 		_ -> Info#{protocol => Protocol:name()}
 	end.
 

--- a/src/gun_http2.erl
+++ b/src/gun_http2.erl
@@ -33,6 +33,7 @@
 -export([timeout/3]).
 -export([stream_info/2]).
 -export([down/1]).
+-export([get_remote_settings/1]).
 
 -record(stream, {
 	id = undefined :: cow_http2:streamid(),
@@ -784,6 +785,9 @@ stream_info(State, StreamRef) ->
 
 down(#http2_state{stream_refs=Refs}) ->
 	maps:keys(Refs).
+
+get_remote_settings(#http2_state{http2_machine=HTTP2Machine}) ->
+	cow_http2_machine:get_remote_settings(HTTP2Machine).
 
 connection_error(#http2_state{socket=Socket, transport=Transport,
 		http2_machine=HTTP2Machine, streams=Streams},


### PR DESCRIPTION
This adds a new http2 entry to the info map, with a remote_settings property. 
Depends on: https://github.com/ninenines/cowlib/pull/107