### PR TITLE
Disconnect when setopts returns an error

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -1780,8 +1780,14 @@ disconnect_flush(State=#state{socket=Socket, messages={OK, Closed, Error}}) ->
 active(State=#state{active=false}) ->
 	State;
 active(State=#state{socket=Socket, transport=Transport}) ->
-	Transport:setopts(Socket, [{active, once}]),
-	State.
+	case Transport:setopts(Socket, [{active, once}]) of
+		ok ->
+			State;
+		{error, closed} ->
+			disconnect(State, closed);
+		Error={error, _} ->
+			disconnect(State, Error)
+	end.
 
 status(State=#state{status={up, OwnerRef}}, NewStatus) ->
 	demonitor(OwnerRef, [flush]),


### PR DESCRIPTION
There is a race condition: After receiving data, before setting the socket back to {active, once}, the server may have closed the socket or an error may have occurred. Since the socket was in passive mode, no message is received. Handling the return value of setopts solves the issue.

----

This was discovered when investigating failing and unstable test cases in Cowboy. The cause was traced back to Gun (which is used for testing Cowboy). The Cowboy test case waits for `gun:await_body` to return `{error, {stream_error, closed}}` which never comes. Cowboy test cases which (sometimes or always) got stuck until timeout or time trap in this way, and solved by this fix, are these:

* `req_SUITE:stream_body_content_length_nofin_error/1` (only CT group is `https`)
* `rfc7231_SUITE:expect_discard_body_close/1` (only CT group is `https` and `https_compress`)