### PR TITLE
Fail fast when request is queued while closing if reconnect is off

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -1364,6 +1364,27 @@ closing(state_timeout, closing_timeout, State=#state{status=Status}) ->
 		_ -> normal
 	end,
 	disconnect(State, Reason);
+%% When reconnect is disabled, fail HTTP/Websocket operations immediately.
+closing(cast, {headers, ReplyTo, StreamRef, _Method, _Path, _Headers, _InitialFlow},
+		State=#state{opts=#{retry := 0}}) ->
+	ReplyTo ! {gun_error, self(), StreamRef, closing},
+	{keep_state, State};
+closing(cast, {request, ReplyTo, StreamRef, _Method, _Path, _Headers, _Body, _InitialFlow},
+		State=#state{opts=#{retry := 0}}) ->
+	ReplyTo ! {gun_error, self(), StreamRef, closing},
+	{keep_state, State};
+closing(cast, {connect, ReplyTo, StreamRef, _Destination, _Headers, _InitialFlow},
+		State=#state{opts=#{retry := 0}}) ->
+	ReplyTo ! {gun_error, self(), StreamRef, closing},
+	{keep_state, State};
+closing(cast, {ws_upgrade, ReplyTo, StreamRef, _Path, _Headers},
+		State=#state{opts=#{retry := 0}}) ->
+	ReplyTo ! {gun_error, self(), StreamRef, closing},
+	{keep_state, State};
+closing(cast, {ws_upgrade, ReplyTo, StreamRef, _Path, _Headers, _WsOpts},
+		State=#state{opts=#{retry := 0}}) ->
+	ReplyTo ! {gun_error, self(), StreamRef, closing},
+	{keep_state, State};
 closing(Type, Event, State) ->
 	handle_common_connected(Type, Event, ?FUNCTION_NAME, State).
 


### PR DESCRIPTION
If a request is created when a connection is in state 'closing', e.g. after receiving an HTTP/2 GOAWAY frame or an HTTP/1.1 `Connection: close` header, an error message is sent back to the caller immediately, if reconnect is off (i.e. if the option retry is set to 0).

This allows an application to retry the request on another connection without waiting for all streams on the current connection to complete.