### PR TITLE
gun:flush/1: flush {gun_tunnel_up, _, _, _} message also.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ ebin/test
 ebin/*.beam
 logs
 test/*.beam
+/.rebar/
+/_build/

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-{cowlib,".*",{git,"https://github.com/ninenines/cowlib","master"}}
+{cowlib,".*",{git,"https://github.com/ninenines/cowlib",{branch,"master"}}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.

--- a/src/gun.erl
+++ b/src/gun.erl
@@ -862,6 +862,8 @@ flush_pid(ServerPid) ->
 			flush_pid(ServerPid);
 		{gun_error, ServerPid, _} ->
 			flush_pid(ServerPid);
+		{gun_tunnel_up, ServerPid, _, _} ->
+			flush_pid(ServerPid);
 		{gun_upgrade, ServerPid, _, _, _} ->
 			flush_pid(ServerPid);
 		{gun_ws, ServerPid, _, _} ->
@@ -886,6 +888,8 @@ flush_ref(StreamRef) ->
 		{gun_push, _, StreamRef, _, _, _, _, _} ->
 			flush_ref(StreamRef);
 		{gun_error, _, StreamRef, _} ->
+			flush_ref(StreamRef);
+		{gun_tunnel_up, _, StreamRef, _} ->
 			flush_ref(StreamRef);
 		{gun_upgrade, _, StreamRef, _, _} ->
 			flush_ref(StreamRef);

--- a/src/gun_cookies.erl
+++ b/src/gun_cookies.erl
@@ -102,7 +102,7 @@ add_cookie_header(Scheme, Authority, PathWithQs, Headers0, Store0) ->
 		_ ->
 			Cookies = [{Name, Value} || #{name := Name, value := Value} <- Cookies0],
 			%% We put cookies at the end of the headers list as it's the least important header.
-			Headers0 ++ [{<<"cookie">>, cow_cookie:cookie(Cookies)}]
+			lists:keystore(<<"cookie">>, 1, Headers0, {<<"cookie">>, cow_cookie:cookie(Cookies)})
 	end,
 	{Headers, Store}.
 

--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -612,6 +612,9 @@ send_request(State=#http_state{socket=Socket, transport=Transport, version=Versi
 			lists:keystore(<<"transfer-encoding">>, 1, Headers1,
 				{<<"transfer-encoding">>, <<"chunked">>});
 		{undefined, _} -> Headers1;
+		{<<>>, _} when Method =:= <<"DELETE">>; Method =:= <<"GET">>;
+				Method =:= <<"HEAD">>; Method =:= <<"OPTIONS">> ->
+			 Headers1;
 		_ ->
 			lists:keystore(<<"content-length">>, 1, Headers1,
 				{<<"content-length">>, integer_to_binary(iolist_size(Body))})


### PR DESCRIPTION
'gun_tunnel_up' support in flush_pid/1, flush_ref/1 is missing now.
Please fix this.