### PR TITLE
Return commands instead of state

### DIFF
--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -546,36 +546,36 @@ close_streams(State, [#stream{ref=StreamRef, reply_to=ReplyTo}|Tail], Reason) ->
 	close_streams(State, Tail, Reason).
 
 %% We don't send a keep-alive when a CONNECT request was initiated.
-keepalive(State=#http_state{streams=[#stream{ref={connect, _, _}}]}, _, EvHandlerState) ->
-	{State, EvHandlerState};
+keepalive(#http_state{streams=[#stream{ref={connect, _, _}}]}, _, EvHandlerState) ->
+	{[], EvHandlerState};
 %% We can only keep-alive by sending an empty line in-between streams.
-keepalive(State=#http_state{socket=Socket, transport=Transport, out=head}, _, EvHandlerState) ->
+keepalive(#http_state{socket=Socket, transport=Transport, out=head}, _, EvHandlerState) ->
 	Transport:send(Socket, <<"\r\n">>),
-	{State, EvHandlerState};
-keepalive(State, _, EvHandlerState) ->
-	{State, EvHandlerState}.
+	{[], EvHandlerState};
+keepalive(_State, _, EvHandlerState) ->
+	{[], EvHandlerState}.
 
 headers(State, StreamRef, ReplyTo, _, _, _, _, _, _, CookieStore, _, EvHandlerState)
 		when is_list(StreamRef) ->
 	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef),
 		{badstate, "The stream is not a tunnel."}},
-	{State, CookieStore, EvHandlerState};
-headers(State=#http_state{opts=Opts, out=head},
+	{[], CookieStore, EvHandlerState};
+headers(State0=#http_state{opts=Opts, out=head},
 		StreamRef, ReplyTo, Method, Host, Port, Path, Headers,
 		InitialFlow0, CookieStore0, EvHandler, EvHandlerState0) ->
-	{Authority, Conn, Out, CookieStore, EvHandlerState} = send_request(State,
+	{Authority, Conn, Out, CookieStore, EvHandlerState} = send_request(State0,
 		StreamRef, ReplyTo, Method, Host, Port, Path, Headers, undefined,
 		CookieStore0, EvHandler, EvHandlerState0, ?FUNCTION_NAME),
 	InitialFlow = initial_flow(InitialFlow0, Opts),
-	{new_stream(State#http_state{connection=Conn, out=Out}, StreamRef, ReplyTo,
-		Method, Authority, Path, InitialFlow),
-		CookieStore, EvHandlerState}.
+	State = new_stream(State0#http_state{connection=Conn, out=Out}, StreamRef,
+		ReplyTo, Method, Authority, Path, InitialFlow),
+	{{state, State}, CookieStore, EvHandlerState}.
 
 request(State, StreamRef, ReplyTo, _, _, _, _, _, _, _, CookieStore, _, EvHandlerState)
 		when is_list(StreamRef) ->
 	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef),
 		{badstate, "The stream is not a tunnel."}},
-	{State, CookieStore, EvHandlerState};
+	{[], CookieStore, EvHandlerState};
 request(State=#http_state{opts=Opts, out=head}, StreamRef, ReplyTo,
 		Method, Host, Port, Path, Headers, Body,
 		InitialFlow0, CookieStore0, EvHandler, EvHandlerState0) ->
@@ -583,8 +583,8 @@ request(State=#http_state{opts=Opts, out=head}, StreamRef, ReplyTo,
 		StreamRef, ReplyTo, Method, Host, Port, Path, Headers, Body,
 		CookieStore0, EvHandler, EvHandlerState0, ?FUNCTION_NAME),
 	InitialFlow = initial_flow(InitialFlow0, Opts),
-	{new_stream(State#http_state{connection=Conn, out=Out}, StreamRef, ReplyTo,
-		Method, Authority, Path, InitialFlow),
+	{{state, new_stream(State#http_state{connection=Conn, out=Out}, StreamRef,
+		ReplyTo, Method, Authority, Path, InitialFlow)},
 		CookieStore, EvHandlerState}.
 
 initial_flow(infinity, #{flow := InitialFlow}) -> InitialFlow;
@@ -704,10 +704,10 @@ data(State=#http_state{socket=Socket, transport=Transport, version=Version,
 						reply_to => ReplyTo
 					},
 					EvHandlerState = EvHandler:request_end(RequestEndEvent, EvHandlerState0),
-					{State#http_state{out=head}, EvHandlerState};
+					{{state, State#http_state{out=head}}, EvHandlerState};
 				body_chunked when Version =:= 'HTTP/1.1' ->
 					Transport:send(Socket, cow_http_te:chunk(Data)),
-					{State, EvHandlerState0};
+					{[], EvHandlerState0};
 				{body, Length} when DataLength =< Length ->
 					Transport:send(Socket, Data),
 					Length2 = Length - DataLength,
@@ -718,13 +718,13 @@ data(State=#http_state{socket=Socket, transport=Transport, version=Version,
 								reply_to => ReplyTo
 							},
 							EvHandlerState = EvHandler:request_end(RequestEndEvent, EvHandlerState0),
-							{State#http_state{out=head}, EvHandlerState};
+							{{state, State#http_state{out=head}}, EvHandlerState};
 						Length2 > 0, IsFin =:= nofin ->
-							{State#http_state{out={body, Length2}}, EvHandlerState0}
+							{{state, State#http_state{out={body, Length2}}}, EvHandlerState0}
 					end;
 				body_chunked -> %% HTTP/1.0
 					Transport:send(Socket, Data),
-					{State, EvHandlerState0}
+					{[], EvHandlerState0}
 			end;
 		_ ->
 			{error_stream_not_found(State, StreamRef, ReplyTo), EvHandlerState0}
@@ -734,12 +734,12 @@ connect(State, StreamRef, ReplyTo, _, _, _, _, _, EvHandlerState)
 		when is_list(StreamRef) ->
 	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef),
 		{badstate, "The stream is not a tunnel."}},
-	{State, EvHandlerState};
+	{[], EvHandlerState};
 connect(State=#http_state{streams=Streams}, StreamRef, ReplyTo, _, _, _, _, _, EvHandlerState)
 		when Streams =/= [] ->
 	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), {badstate,
 		"CONNECT can only be used with HTTP/1.1 when no other streams are active."}},
-	{State, EvHandlerState};
+	{[], EvHandlerState};
 connect(State=#http_state{socket=Socket, transport=Transport, opts=Opts, version=Version},
 		StreamRef, ReplyTo, Destination=#{host := Host0}, _TunnelInfo, Headers0, InitialFlow0,
 		EvHandler, EvHandlerState0) ->
@@ -786,8 +786,8 @@ connect(State=#http_state{socket=Socket, transport=Transport, opts=Opts, version
 	},
 	EvHandlerState = EvHandler:request_end(RequestEndEvent, EvHandlerState2),
 	InitialFlow = initial_flow(InitialFlow0, Opts),
-	{new_stream(State, {connect, StreamRef, Destination}, ReplyTo,
-		<<"CONNECT">>, Authority, <<>>, InitialFlow),
+	{{state, new_stream(State, {connect, StreamRef, Destination}, ReplyTo,
+		<<"CONNECT">>, Authority, <<>>, InitialFlow)},
 		EvHandlerState}.
 
 %% We can't cancel anything, we can just stop forwarding messages to the owner.
@@ -801,7 +801,7 @@ cancel(State0, StreamRef, ReplyTo, EvHandler, EvHandlerState0) ->
 				endpoint => local,
 				reason => cancel
 			}, EvHandlerState0),
-			{State, EvHandlerState};
+			{{state, State}, EvHandlerState};
 		false ->
 			{error_stream_not_found(State0, StreamRef, ReplyTo), EvHandlerState0}
 	end.
@@ -831,12 +831,12 @@ down(#http_state{streams=Streams}) ->
 error_stream_closed(State, StreamRef, ReplyTo) ->
 	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), {badstate,
 		"The stream has already been closed."}},
-	State.
+	{state, State}.
 
 error_stream_not_found(State, StreamRef, ReplyTo) ->
 	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), {badstate,
 		"The stream cannot be found."}},
-	State.
+	{state, State}.
 
 %% Headers information retrieval.
 
@@ -927,12 +927,12 @@ ws_upgrade(State, StreamRef, ReplyTo, _, _, _, _, _, CookieStore, _, EvHandlerSt
 		when is_list(StreamRef) ->
 	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef),
 		{badstate, "The stream is not a tunnel."}},
-	{State, CookieStore, EvHandlerState};
+	{[], CookieStore, EvHandlerState};
 ws_upgrade(State=#http_state{version='HTTP/1.0'},
 		StreamRef, ReplyTo, _, _, _, _, _, CookieStore, _, EvHandlerState) ->
 	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), {badstate,
 		"Websocket cannot be used over an HTTP/1.0 connection."}},
-	{State, CookieStore, EvHandlerState};
+	{[], CookieStore, EvHandlerState};
 ws_upgrade(State=#http_state{out=head}, StreamRef, ReplyTo,
 		Host, Port, Path, Headers0, WsOpts, CookieStore0, EvHandler, EvHandlerState0) ->
 	{Headers1, GunExtensions} = case maps:get(compress, WsOpts, false) of
@@ -960,9 +960,9 @@ ws_upgrade(State=#http_state{out=head}, StreamRef, ReplyTo,
 		StreamRef, ReplyTo, <<"GET">>, Host, Port, Path, Headers, undefined,
 		CookieStore0, EvHandler, EvHandlerState0, ?FUNCTION_NAME),
 	InitialFlow = maps:get(flow, WsOpts, infinity),
-	{new_stream(State#http_state{connection=Conn, out=Out},
+	{{state, new_stream(State#http_state{connection=Conn, out=Out},
 		#websocket{ref=StreamRef, reply_to=ReplyTo, key=Key, extensions=GunExtensions, opts=WsOpts},
-		ReplyTo, <<"GET">>, Authority, Path, InitialFlow),
+		ReplyTo, <<"GET">>, Authority, Path, InitialFlow)},
 		CookieStore, EvHandlerState}.
 
 ws_handshake(Buffer, State, Ws=#websocket{key=Key}, Headers) ->

--- a/src/gun_raw.erl
+++ b/src/gun_raw.erl
@@ -44,10 +44,10 @@ init(ReplyTo, Socket, Transport, Opts) ->
 	StreamRef = maps:get(stream_ref, Opts, undefined),
 	{connected_data_only, #raw_state{ref=StreamRef, reply_to=ReplyTo, socket=Socket, transport=Transport}}.
 
-handle(Data, State=#raw_state{ref=StreamRef, reply_to=ReplyTo}, CookieStore, _, EvHandlerState) ->
+handle(Data, #raw_state{ref=StreamRef, reply_to=ReplyTo}, CookieStore, _, EvHandlerState) ->
 	%% When we take over the entire connection there is no stream reference.
 	ReplyTo ! {gun_data, self(), StreamRef, nofin, Data},
-	{{state, State}, CookieStore, EvHandlerState}.
+	{[], CookieStore, EvHandlerState}.
 
 %% We can always close immediately.
 closing(_, _, _, EvHandlerState) ->
@@ -57,7 +57,7 @@ close(_, _, _, EvHandlerState) ->
 	EvHandlerState.
 
 %% @todo Initiate closing on IsFin=fin.
-data(State=#raw_state{ref=StreamRef, socket=Socket, transport=Transport}, StreamRef,
+data(#raw_state{ref=StreamRef, socket=Socket, transport=Transport}, StreamRef,
 		_ReplyTo, _IsFin, Data, _EvHandler, EvHandlerState) ->
 	Transport:send(Socket, Data),
-	{State, EvHandlerState}.
+	{[], EvHandlerState}.

--- a/src/gun_tunnel.erl
+++ b/src/gun_tunnel.erl
@@ -273,32 +273,32 @@ close(_Reason, _State, _EvHandler, EvHandlerState) ->
 	%% @todo Closing must be propagated to tunnels.
 	EvHandlerState.
 
-keepalive(State, _EvHandler, EvHandlerState) ->
+keepalive(_State, _EvHandler, EvHandlerState) ->
 	%% @todo Need to figure out how to handle keepalive for tunnels.
-	{State, EvHandlerState}.
+	{[], EvHandlerState}.
 
 %% We pass the headers forward and optionally dereference StreamRef.
-headers(State=#tunnel_state{protocol=Proto, protocol_state=ProtoState0},
+headers(State0=#tunnel_state{protocol=Proto, protocol_state=ProtoState0},
 		StreamRef0, ReplyTo, Method, Host, Port, Path, Headers,
 		InitialFlow, CookieStore0, EvHandler, EvHandlerState0) ->
-	StreamRef = maybe_dereference(State, StreamRef0),
-	{ProtoState, CookieStore, EvHandlerState} = Proto:headers(ProtoState0, StreamRef,
+	StreamRef = maybe_dereference(State0, StreamRef0),
+	{Commands, CookieStore, EvHandlerState1} = Proto:headers(ProtoState0, StreamRef,
 		ReplyTo, Method, Host, Port, Path, Headers,
 		InitialFlow, CookieStore0, EvHandler, EvHandlerState0),
-	{State#tunnel_state{protocol_state=ProtoState},
-		CookieStore, EvHandlerState}.
+	{State, EvHandlerState} = commands(Commands, State0, EvHandler, EvHandlerState1),
+	{{state, State}, CookieStore, EvHandlerState}.
 
 %% We pass the request forward and optionally dereference StreamRef.
-request(State=#tunnel_state{protocol=Proto, protocol_state=ProtoState0,
+request(State0=#tunnel_state{protocol=Proto, protocol_state=ProtoState0,
 		info=#{origin_host := OriginHost, origin_port := OriginPort}},
 		StreamRef0, ReplyTo, Method, _Host, _Port, Path, Headers, Body,
 		InitialFlow, CookieStore0, EvHandler, EvHandlerState0) ->
-	StreamRef = maybe_dereference(State, StreamRef0),
-	{ProtoState, CookieStore, EvHandlerState} = Proto:request(ProtoState0, StreamRef,
+	StreamRef = maybe_dereference(State0, StreamRef0),
+	{Commands, CookieStore, EvHandlerState1} = Proto:request(ProtoState0, StreamRef,
 		ReplyTo, Method, OriginHost, OriginPort, Path, Headers, Body,
 		InitialFlow, CookieStore0, EvHandler, EvHandlerState0),
-	{State#tunnel_state{protocol_state=ProtoState},
-		CookieStore, EvHandlerState}.
+	{State, EvHandlerState} = commands(Commands, State0, EvHandler, EvHandlerState1),
+	{{state, State}, CookieStore, EvHandlerState}.
 
 %% When the next tunnel is SOCKS we pass the data forward directly.
 %% This is needed because SOCKS has no StreamRef and the data cannot
@@ -306,9 +306,10 @@ request(State=#tunnel_state{protocol=Proto, protocol_state=ProtoState0,
 data(State=#tunnel_state{protocol=Proto, protocol_state=ProtoState0,
 		protocol_origin={origin, _, _, _, socks5}},
 		StreamRef, ReplyTo, IsFin, Data, EvHandler, EvHandlerState0) ->
-	{ProtoState, EvHandlerState} = Proto:data(ProtoState0, StreamRef,
+	{Commands, EvHandlerState1} = Proto:data(ProtoState0, StreamRef,
 		ReplyTo, IsFin, Data, EvHandler, EvHandlerState0),
-	{State#tunnel_state{protocol_state=ProtoState}, EvHandlerState};
+	{State1, EvHandlerState} = commands(Commands, State, EvHandler, EvHandlerState1),
+	{{state, State1}, EvHandlerState};
 %% CONNECT tunnels pass the data forward and dereference StreamRef
 %% unless they are the recipient of the callback, in which case the
 %% data is sent to the socket.
@@ -319,12 +320,14 @@ data(State=#tunnel_state{socket=Socket, transport=Transport,
 	case StreamRef0 of
 		TunnelStreamRef ->
 			ok = Transport:send(Socket, Data),
-			{State, EvHandlerState0};
+			{[], EvHandlerState0};
 		_ ->
 			StreamRef = maybe_dereference(State, StreamRef0),
-			{ProtoState, EvHandlerState} = Proto:data(ProtoState0, StreamRef,
+			{Commands, EvHandlerState1} = Proto:data(ProtoState0, StreamRef,
 				ReplyTo, IsFin, Data, EvHandler, EvHandlerState0),
-			{State#tunnel_state{protocol_state=ProtoState}, EvHandlerState}
+			{State1, EvHandlerState} = commands(Commands, State,
+				EvHandler, EvHandlerState1),
+			{{state, State1}, EvHandlerState}
 	end.
 
 %% We pass the CONNECT request forward and optionally dereference StreamRef.
@@ -333,17 +336,19 @@ connect(State=#tunnel_state{info=#{origin_host := Host, origin_port := Port},
 		StreamRef0, ReplyTo, Destination, _, Headers, InitialFlow,
 		EvHandler, EvHandlerState0) ->
 	StreamRef = maybe_dereference(State, StreamRef0),
-	{ProtoState, EvHandlerState} = Proto:connect(ProtoState0, StreamRef,
+	{Commands, EvHandlerState1} = Proto:connect(ProtoState0, StreamRef,
 		ReplyTo, Destination, #{host => Host, port => Port}, Headers, InitialFlow,
 		EvHandler, EvHandlerState0),
-	{State#tunnel_state{protocol_state=ProtoState}, EvHandlerState}.
+	{State1, EvHandlerState} = commands(Commands, State, EvHandler, EvHandlerState1),
+	{{state, State1}, EvHandlerState}.
 
 cancel(State=#tunnel_state{protocol=Proto, protocol_state=ProtoState0},
 		StreamRef0, ReplyTo, EvHandler, EvHandlerState0) ->
 	StreamRef = maybe_dereference(State, StreamRef0),
-	{ProtoState, EvHandlerState} = Proto:cancel(ProtoState0, StreamRef,
+	{Commands, EvHandlerState1} = Proto:cancel(ProtoState0, StreamRef,
 		ReplyTo, EvHandler, EvHandlerState0),
-	{State#tunnel_state{protocol_state=ProtoState}, EvHandlerState}.
+	{State1, EvHandlerState} = commands(Commands, State, EvHandler, EvHandlerState1),
+	{{state, State1}, EvHandlerState}.
 
 timeout(State=#tunnel_state{protocol=Proto, protocol_state=ProtoState0}, Msg, TRef) ->
 	case Proto:timeout(ProtoState0, Msg, TRef) of
@@ -426,11 +431,11 @@ ws_upgrade(State=#tunnel_state{info=TunnelInfo, protocol=Proto, protocol_state=P
 		origin_host := Host,
 		origin_port := Port
 	} = TunnelInfo,
-	{ProtoState, CookieStore, EvHandlerState} = Proto:ws_upgrade(ProtoState0, StreamRef, ReplyTo,
+	{Commands, CookieStore, EvHandlerState1} = Proto:ws_upgrade(ProtoState0, StreamRef, ReplyTo,
 		Host, Port, Path, Headers, WsOpts,
 		CookieStore0, EvHandler, EvHandlerState0),
-	{State#tunnel_state{protocol_state=ProtoState},
-		CookieStore, EvHandlerState}.
+	{State1, EvHandlerState} = commands(Commands, State, EvHandler, EvHandlerState1),
+	{{state, State1}, CookieStore, EvHandlerState}.
 
 ws_send(Frames, State0=#tunnel_state{protocol=Proto, protocol_state=ProtoState},
 		StreamRef0, ReplyTo, EvHandler, EvHandlerState0) ->

--- a/src/gun_ws.erl
+++ b/src/gun_ws.erl
@@ -299,8 +299,7 @@ close(_, _, _, EvHandlerState) ->
 	EvHandlerState.
 
 keepalive(State=#ws_state{reply_to=ReplyTo}, EvHandler, EvHandlerState0) ->
-	{[], EvHandlerState} = send(ping, State, ReplyTo, EvHandler, EvHandlerState0),
-	{State, EvHandlerState}.
+	send(ping, State, ReplyTo, EvHandler, EvHandlerState0).
 
 %% Send one frame.
 send(Frame, State=#ws_state{stream_ref=StreamRef,


### PR DESCRIPTION
A command is returned instead of a state by these Protocol functions:

    headers/12
    request/13
    keepalive/3
    data/7
    connect/9
    ws_upgrade/11
    cancel/5
