### PR TITLE
Fix infinite loop when connecting from a source in another subnet

### DIFF
--- a/src/gun_tcp.erl
+++ b/src/gun_tcp.erl
@@ -76,7 +76,7 @@ connect(#{ip_addresses := IPs, port := Port, tcp_module := Mod, tcp_opts := Opts
 	end,
 	case Res of
 		{ok, S} -> {ok, S};
-		Error -> maybe_exit(Error)
+		Error -> Error
 	end.
 
 try_connect([IP|IPs], Port, Opts, Timer, Mod, _) ->


### PR DESCRIPTION
There's an infinite loop when trying to connect to an ip if you provide a source ip address in another subnet, this can be reproduced like this:

`:gun_pool.request("GET", "/tmp1", [{"host", "20.20.0.1:8888"}], "", %{start_pool_if_missing: %{conn_opts: %{protocols:
 [:http2], tcp_opts: [ip: {127, 0, 0, 1}]}}})
`
