### PR TITLE
Add state (current state name) info field in gun:info/1

### DIFF
--- a/doc/src/manual/gun.info.asciidoc
+++ b/doc/src/manual/gun.info.asciidoc
@@ -23,7 +23,7 @@ Info :: #{
     origin_port    => inet:port_number(),
     intermediaries => [Intermediary],
     cookie_store   => gun_cookies:cookie_store(),
-    state          => atom()
+    state_name     => atom()
 }
 Intermediary :: #{
     type      => connect | socks5,

--- a/doc/src/manual/gun.info.asciidoc
+++ b/doc/src/manual/gun.info.asciidoc
@@ -23,9 +23,7 @@ Info :: #{
     origin_port    => inet:port_number(),
     intermediaries => [Intermediary],
     cookie_store   => gun_cookies:cookie_store(),
-    state          => not_connected | domain_lookup | connecting |
-                      initial_tls_handshake | tls_handshake | connected |
-                      closing
+    state          => atom()
 }
 Intermediary :: #{
     type      => connect | socks5,

--- a/doc/src/manual/gun.info.asciidoc
+++ b/doc/src/manual/gun.info.asciidoc
@@ -22,7 +22,10 @@ Info :: #{
     origin_host    => inet:hostname() | inet:ip_address(),
     origin_port    => inet:port_number(),
     intermediaries => [Intermediary],
-    cookie_store   => gun_cookies:cookie_store()
+    cookie_store   => gun_cookies:cookie_store(),
+    state          => not_connected | domain_lookup | connecting |
+                      initial_tls_handshake | tls_handshake | connected |
+                      closing
 }
 Intermediary :: #{
     type      => connect | socks5,

--- a/src/gun.erl
+++ b/src/gun.erl
@@ -474,7 +474,7 @@ info(ServerPid) ->
 		origin_port => OriginPort,
 		intermediaries => intermediaries_info(Intermediaries, []),
 		cookie_store => CookieStore,
-		state => CurrentStateName
+		state_name => CurrentStateName
 	},
 	Info = case Socket of
 		undefined ->

--- a/src/gun.erl
+++ b/src/gun.erl
@@ -447,7 +447,7 @@ set_owner(ServerPid, NewOwnerPid) ->
 
 -spec info(pid()) -> map().
 info(ServerPid) ->
-	{_, #state{
+	{CurrentStateName, #state{
 		owner=Owner,
 		socket=Socket,
 		transport=Transport,
@@ -473,7 +473,8 @@ info(ServerPid) ->
 		origin_host => OriginHost,
 		origin_port => OriginPort,
 		intermediaries => intermediaries_info(Intermediaries, []),
-		cookie_store => CookieStore
+		cookie_store => CookieStore,
+		state => CurrentStateName
 	},
 	Info = case Socket of
 		undefined ->

--- a/test/gun_SUITE.erl
+++ b/test/gun_SUITE.erl
@@ -172,7 +172,7 @@ info(_) ->
 	{ok, {_, Port}} = inet:sockname(ListenSocket),
 	{ok, Pid} = gun:open("localhost", Port),
 	{ok, _} = gen_tcp:accept(ListenSocket, 5000),
-	#{sock_ip := _, sock_port := _, state := connected} = gun:info(Pid),
+	#{sock_ip := _, sock_port := _, state_name := connected} = gun:info(Pid),
 	gun:close(Pid).
 
 keepalive_infinity(_) ->

--- a/test/gun_SUITE.erl
+++ b/test/gun_SUITE.erl
@@ -172,7 +172,7 @@ info(_) ->
 	{ok, {_, Port}} = inet:sockname(ListenSocket),
 	{ok, Pid} = gun:open("localhost", Port),
 	{ok, _} = gen_tcp:accept(ListenSocket, 5000),
-	#{sock_ip := _, sock_port := _} = gun:info(Pid),
+	#{sock_ip := _, sock_port := _, state := connected} = gun:info(Pid),
 	gun:close(Pid).
 
 keepalive_infinity(_) ->


### PR DESCRIPTION
It's useful to be able to check the HTTP connection status (connected, closing, not connected, etc.). The current gen_statem state name provides exactly this info. This commit adds it to `gun:info/1` under the key `state`.
