### PR TITLE
Make Protocol:init/4 return an ok-tuple

### DIFF
--- a/src/gun.erl
+++ b/src/gun.erl
@@ -1237,7 +1237,8 @@ connected_ws_only(Type, Event, State) ->
 connected(internal, {connected, Socket, NewProtocol},
 		State0=#state{owner=Owner, opts=Opts, transport=Transport}) ->
 	{Protocol, ProtoOpts} = gun_protocols:handler_and_opts(NewProtocol, Opts),
-	{StateName, ProtoState} = Protocol:init(Owner, Socket, Transport, ProtoOpts),
+	%% @todo Handle error result from Protocol:init/4
+	{ok, StateName, ProtoState} = Protocol:init(Owner, Socket, Transport, ProtoOpts),
 	Owner ! {gun_up, self(), Protocol:name()},
 	case active(State0#state{socket=Socket, protocol=Protocol, protocol_state=ProtoState}) of
 		{ok, State} ->
@@ -1679,7 +1680,8 @@ commands([{switch_protocol, NewProtocol, ReplyTo}], State0=#state{
 		#{tunnel_transport := _} -> ProtoOpts0;
 		_ -> ProtoOpts0#{tunnel_transport => tcp}
 	end,
-	{StateName, ProtoState} = Protocol:init(ReplyTo, Socket, Transport, ProtoOpts),
+	%% @todo Handle error result from Protocol:init/4
+	{ok, StateName, ProtoState} = Protocol:init(ReplyTo, Socket, Transport, ProtoOpts),
 	ProtocolChangedEvent = case ProtoOpts of
 		#{stream_ref := StreamRef} ->
 			#{stream_ref => StreamRef, protocol => Protocol:name()};

--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -120,7 +120,7 @@ default_keepalive() -> infinity.
 init(_ReplyTo, Socket, Transport, Opts) ->
 	BaseStreamRef = maps:get(stream_ref, Opts, undefined),
 	Version = maps:get(version, Opts, 'HTTP/1.1'),
-	{connected, #http_state{socket=Socket, transport=Transport,
+	{ok, connected, #http_state{socket=Socket, transport=Transport,
 		opts=Opts, version=Version, base_stream_ref=BaseStreamRef}}.
 
 switch_transport(Transport, Socket, State) ->

--- a/src/gun_http2.erl
+++ b/src/gun_http2.erl
@@ -186,7 +186,7 @@ init(ReplyTo, Socket, Transport, Opts0) ->
 		opts=Opts, base_stream_ref=BaseStreamRef, tunnel_transport=TunnelTransport,
 		content_handlers=Handlers, http2_machine=HTTP2Machine},
 	Transport:send(Socket, Preface),
-	{connected, State}.
+	{ok, connected, State}.
 
 switch_transport(Transport, Socket, State) ->
 	State#http2_state{socket=Socket, transport=Transport}.
@@ -609,7 +609,8 @@ headers_frame_connect_websocket(State, Stream=#stream{ref=StreamRef, reply_to=Re
 		handler => Handler,
 		opts => WsOpts
 	},
-	{connected_ws_only, ProtoState} = Proto:init(
+	%% @todo Handle error result from Proto:init/4
+	{ok, connected_ws_only, ProtoState} = Proto:init(
 		ReplyTo, OriginSocket, gun_tcp_proxy, ProtoOpts),
 	{store_stream(State, Stream#stream{tunnel=Tunnel#tunnel{state=established,
 		protocol=Proto, protocol_state=ProtoState}}),

--- a/src/gun_raw.erl
+++ b/src/gun_raw.erl
@@ -42,7 +42,7 @@ has_keepalive() -> false.
 
 init(ReplyTo, Socket, Transport, Opts) ->
 	StreamRef = maps:get(stream_ref, Opts, undefined),
-	{connected_data_only, #raw_state{ref=StreamRef, reply_to=ReplyTo, socket=Socket, transport=Transport}}.
+	{ok, connected_data_only, #raw_state{ref=StreamRef, reply_to=ReplyTo, socket=Socket, transport=Transport}}.
 
 handle(Data, #raw_state{ref=StreamRef, reply_to=ReplyTo}, CookieStore, _, EvHandlerState) ->
 	%% When we take over the entire connection there is no stream reference.

--- a/src/gun_socks.erl
+++ b/src/gun_socks.erl
@@ -93,7 +93,8 @@ init(ReplyTo, Socket, Transport, Opts) ->
 		none -> <<0>>
 	end || A <- Auth>>,
 	Transport:send(Socket, [<<5, (length(Auth))>>, Methods]),
-	{connected_no_input, #socks_state{ref=StreamRef, reply_to=ReplyTo, socket=Socket, transport=Transport,
+	{ok, connected_no_input, #socks_state{ref=StreamRef, reply_to=ReplyTo,
+		socket=Socket, transport=Transport,
 		opts=Opts, version=Version, status=auth_method_select}}.
 
 switch_transport(Transport, Socket, State) ->

--- a/src/gun_tunnel.erl
+++ b/src/gun_tunnel.erl
@@ -113,7 +113,8 @@ init(ReplyTo, OriginSocket, OriginTransport, Opts=#{stream_ref := StreamRef, tun
 		%% Initialize the protocol.
 		#{new_protocol := NewProtocol} ->
 			{Proto, ProtoOpts} = gun_protocols:handler_and_opts(NewProtocol, Opts),
-			{_, ProtoState} = Proto:init(ReplyTo, OriginSocket, OriginTransport,
+			%% @todo Handle error result from Proto:init/4
+			{ok, _, ProtoState} = Proto:init(ReplyTo, OriginSocket, OriginTransport,
 				ProtoOpts#{stream_ref => StreamRef, tunnel_transport => tcp}),
 			EvHandlerState = EvHandler:protocol_changed(#{
 				stream_ref => StreamRef,
@@ -195,7 +196,8 @@ handle_continue(ContinueStreamRef, {gun_tls_proxy, ProxyPid, {ok, Negotiated},
 		reply_to => ReplyTo,
 		stream_ref => StreamRef
 	},
-	{_, ProtoState} = Proto:init(ReplyTo, OriginSocket, gun_tcp_proxy,
+	%% @todo Handle error result from Proto:init/4
+	{ok, _, ProtoState} = Proto:init(ReplyTo, OriginSocket, gun_tcp_proxy,
 		ProtoOpts#{stream_ref => StreamRef, tunnel_transport => tls}),
 	ReplyTo ! {gun_tunnel_up, self(), StreamRef, Proto:name()},
 	{{state, State#tunnel_state{protocol=Proto, protocol_state=ProtoState}},
@@ -476,7 +478,8 @@ commands([{switch_protocol, NewProtocol, ReplyTo}|Tail],
 		EvHandler, EvHandlerState0) ->
 	{Proto, ProtoOpts} = gun_protocols:handler_and_opts(NewProtocol, Opts),
 	%% This should only apply to Websocket for the time being.
-	{connected_ws_only, ProtoState} = Proto:init(ReplyTo, Socket, Transport, ProtoOpts),
+	%% @todo Handle error result from Proto:init/4
+	{ok, connected_ws_only, ProtoState} = Proto:init(ReplyTo, Socket, Transport, ProtoOpts),
 	#{stream_ref := StreamRef} = ProtoOpts,
 	EvHandlerState = EvHandler:protocol_changed(#{
 		stream_ref => StreamRef,

--- a/src/gun_ws.erl
+++ b/src/gun_ws.erl
@@ -140,7 +140,7 @@ default_keepalive() -> infinity.
 init(ReplyTo, Socket, Transport, #{stream_ref := StreamRef, headers := Headers,
 		extensions := Extensions, flow := InitialFlow, handler := Handler, opts := Opts}) ->
 	{ok, HandlerState} = Handler:init(ReplyTo, StreamRef, Headers, Opts),
-	{connected_ws_only, #ws_state{reply_to=ReplyTo, stream_ref=StreamRef,
+	{ok, connected_ws_only, #ws_state{reply_to=ReplyTo, stream_ref=StreamRef,
 		socket=Socket, transport=Transport, opts=Opts, extensions=Extensions,
 		flow=InitialFlow, handler=Handler, handler_state=HandlerState}}.
 


### PR DESCRIPTION
This is a preparation for allowing init/4 to return an ok or an
error tuple.

This part was done as part preparation for handling send errors as discussed here:
https://github.com/ninenines/gun/pull/243#discussion_r824856311