### PR TITLE
Add allow_http10_connect in http_opts

### DIFF
--- a/doc/src/manual/gun.asciidoc
+++ b/doc/src/manual/gun.asciidoc
@@ -153,7 +153,8 @@ http_opts() :: #{
     flow                        => pos_integer(),
     keepalive                   => timeout(),
     transform_header_name       => fun((binary()) -> binary()),
-    version                     => 'HTTP/1.1' | 'HTTP/1.0'
+    version                     => 'HTTP/1.1' | 'HTTP/1.0',
+    allow_http10_connect        => boolean()
 }
 ----
 
@@ -199,6 +200,11 @@ considers the case of header names to be significant.
 version (`'HTTP/1.1'`)::
 
 HTTP version to use.
+
+allow_http10_connect (false)::
+
+Whether an HTTP Proxy responding with HTTP/1.0 after CONNECT will
+be allowed to establish a tunnel.
 
 === http2_opts()
 
@@ -574,6 +580,7 @@ when receiving a ping.
 
 == Changelog
 
+* *2.0*: The option `allow_http10_connect` was added.
 * *2.0*: The `stream_ref()` type was added.
 * *2.0*: The option `cookie_store` was added. It can be used
          to configure a cookie store that Gun will use

--- a/src/gun.erl
+++ b/src/gun.erl
@@ -208,6 +208,7 @@
 	keepalive => timeout(),
 	transform_header_name => fun((binary()) -> binary()),
 	version => 'HTTP/1.1' | 'HTTP/1.0',
+	allow_http10_connect => boolean(),
 
 	%% Internal.
 	tunnel_transport => tcp | tls


### PR DESCRIPTION
When true, this option permits out-of-spec proxy servers that respond with HTTP/1.0 on the response to the CONNECT. Default behaviour is to only allow HTTP/1.1.

This PR is submitted to address #303 .

These changes pass my local testing, which includes:
1. A successful tunnel through goproxy with `allow_http10_connect => true`, which responds with HTTP/1.0 on the CONNECT response. ~~[goproxy issue](https://github.com/goproxy/goproxy/issues/38)~~[1]
2. An new error response[0] with `allow_http10_connect => false` when HTTP/1.0 is provided.
3. make eunit
4. make ct

I've not attempted to add any test cases or documentation yet. The test cases for tunneling are quite comprehensive, so I would need some guidance on the best way to approach this.

[0] New error response:
```
** exception error: no match of right hand side value {error,{stream_error,{badstate,"CONNECT cannot be used over an HTTP/1.0 connection by default. See http_opts `allow_http10_connect`."}}}
```

[1] Edit: I opened the referenced goproxy issue under the wrong project by mistake, so please ignore this particular link for now. If I am able to open the correct issue, I will edit this message later on.