### PR TITLE
Reply to fun or MFA

### DIFF
--- a/doc/src/manual/gun.asciidoc
+++ b/doc/src/manual/gun.asciidoc
@@ -441,7 +441,7 @@ Request headers.
 ----
 req_opts() :: #{
     flow     => pos_integer(),
-    reply_to => pid()
+    reply_to => pid() | {module(), atom(), list()} | fun((_) -> _) | {fun(), list()}
 }
 ----
 
@@ -456,7 +456,8 @@ flow control is disabled.
 
 reply_to (`self()`)::
 
-The pid of the process that will receive the response messages.
+The pid of the process that will receive the response messages,
+alternatively a function that will be called with the reponse.
 
 === socks_opts()
 

--- a/src/gun_data_h.erl
+++ b/src/gun_data_h.erl
@@ -29,5 +29,5 @@ init(ReplyTo, StreamRef, _, _, _) ->
 
 -spec handle(fin | nofin, binary(), State) -> {done, 1, State} when State::#state{}.
 handle(IsFin, Data, State=#state{reply_to=ReplyTo, stream_ref=StreamRef}) ->
-	ReplyTo ! {gun_data, self(), StreamRef, IsFin, Data},
+	gun:reply(ReplyTo, {gun_data, self(), StreamRef, IsFin, Data}),
 	{done, 1, State}.

--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -238,7 +238,7 @@ handle(Data, State=#http_state{in=body_trailer, buffer=Buffer, connection=Conn,
 			{Trailers, Rest} = cow_http:parse_headers(Data2),
 			%% @todo We probably want to pass this to gun_content_handler?
 			RealStreamRef = stream_ref(State, StreamRef),
-			ReplyTo ! {gun_trailers, self(), RealStreamRef, Trailers},
+			gun:reply(ReplyTo, {gun_trailers, self(), RealStreamRef, Trailers}),
 			ResponseEvent = #{
 				stream_ref => RealStreamRef,
 				reply_to => ReplyTo
@@ -319,7 +319,7 @@ handle_connect(Rest, State=#http_state{
 	%% @todo If the stream is cancelled we probably shouldn't finish the CONNECT setup.
 	_ = case Stream of
 		#stream{is_alive=false} -> ok;
-		_ -> ReplyTo ! {gun_response, self(), RealStreamRef, fin, Status, Headers}
+		_ -> gun:reply(ReplyTo, {gun_response, self(), RealStreamRef, fin, Status, Headers})
 	end,
 	%% @todo Figure out whether the event should trigger if the stream was cancelled.
 	EvHandlerState1 = EvHandler:response_headers(#{
@@ -355,7 +355,7 @@ handle_connect(Rest, State=#http_state{
 			[NewProtocol0] = maps:get(protocols, Destination, [http]),
 			NewProtocol = gun_protocols:add_stream_ref(NewProtocol0, RealStreamRef),
 			Protocol = gun_protocols:handler(NewProtocol),
-			ReplyTo ! {gun_tunnel_up, self(), RealStreamRef, Protocol:name()},
+			gun:reply(ReplyTo, {gun_tunnel_up, self(), RealStreamRef, Protocol:name()}),
 			{[
 				{origin, <<"http">>, NewHost, NewPort, connect},
 				{switch_protocol, NewProtocol, ReplyTo}
@@ -382,17 +382,17 @@ handle_inform(Rest, State=#http_state{
 				%% @todo We shouldn't ignore Rest.
 				{_, Upgrade0} = lists:keyfind(<<"upgrade">>, 1, Headers),
 				Upgrade = cow_http_hd:parse_upgrade(Upgrade0),
-				ReplyTo ! {gun_upgrade, self(), stream_ref(State, StreamRef), Upgrade, Headers},
+				gun:reply(ReplyTo, {gun_upgrade, self(), stream_ref(State, StreamRef), Upgrade, Headers}),
 				%% @todo We probably need to add_stream_ref?
 				{{switch_protocol, raw, ReplyTo}, CookieStore, EvHandlerState0}
 			catch _:_ ->
 				%% When the Upgrade header is missing or invalid we treat
 				%% the response as any other informational response.
-				ReplyTo ! {gun_inform, self(), stream_ref(State, StreamRef), Status, Headers},
+				gun:reply(ReplyTo, {gun_inform, self(), stream_ref(State, StreamRef), Status, Headers}),
 				handle(Rest, State, CookieStore, EvHandler, EvHandlerState)
 			end;
 		_ ->
-			ReplyTo ! {gun_inform, self(), stream_ref(State, StreamRef), Status, Headers},
+			gun:reply(ReplyTo, {gun_inform, self(), stream_ref(State, StreamRef), Status, Headers}),
 			handle(Rest, State, CookieStore, EvHandler, EvHandlerState)
 	end.
 
@@ -407,7 +407,7 @@ handle_response(Rest, State=#http_state{version=ClientVersion, opts=Opts, connec
 		false ->
 			{undefined, EvHandlerState0};
 		true ->
-			ReplyTo ! {gun_response, self(), RealStreamRef, IsFin, Status, Headers},
+			gun:reply(ReplyTo, {gun_response, self(), RealStreamRef, IsFin, Status, Headers}),
 			EvHandlerState1 = EvHandler:response_headers(#{
 				stream_ref => RealStreamRef,
 				reply_to => ReplyTo,
@@ -546,7 +546,7 @@ close_streams(_, [], _) ->
 close_streams(State, [#stream{is_alive=false}|Tail], Reason) ->
 	close_streams(State, Tail, Reason);
 close_streams(State, [#stream{ref=StreamRef, reply_to=ReplyTo}|Tail], Reason) ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), Reason},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef), Reason}),
 	close_streams(State, Tail, Reason).
 
 %% We don't send a keep-alive when a CONNECT request was initiated.
@@ -563,8 +563,8 @@ keepalive(_State, _, EvHandlerState) ->
 
 headers(State, StreamRef, ReplyTo, _, _, _, _, _, _, CookieStore, _, EvHandlerState)
 		when is_list(StreamRef) ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef),
-		{badstate, "The stream is not a tunnel."}},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef),
+		{badstate, "The stream is not a tunnel."}}),
 	{[], CookieStore, EvHandlerState};
 headers(State=#http_state{opts=Opts, out=head},
 		StreamRef, ReplyTo, Method, Host, Port, Path, Headers,
@@ -584,8 +584,8 @@ headers(State=#http_state{opts=Opts, out=head},
 
 request(State, StreamRef, ReplyTo, _, _, _, _, _, _, _, CookieStore, _, EvHandlerState)
 		when is_list(StreamRef) ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef),
-		{badstate, "The stream is not a tunnel."}},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef),
+		{badstate, "The stream is not a tunnel."}}),
 	{[], CookieStore, EvHandlerState};
 request(State=#http_state{opts=Opts, out=head}, StreamRef, ReplyTo,
 		Method, Host, Port, Path, Headers, Body,
@@ -762,13 +762,13 @@ data(State=#http_state{socket=Socket, transport=Transport, version=Version,
 
 connect(State, StreamRef, ReplyTo, _, _, _, _, _, EvHandlerState)
 		when is_list(StreamRef) ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef),
-		{badstate, "The stream is not a tunnel."}},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef),
+		{badstate, "The stream is not a tunnel."}}),
 	{[], EvHandlerState};
 connect(State=#http_state{streams=Streams}, StreamRef, ReplyTo, _, _, _, _, _, EvHandlerState)
 		when Streams =/= [] ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), {badstate,
-		"CONNECT can only be used with HTTP/1.1 when no other streams are active."}},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef), {badstate,
+		"CONNECT can only be used with HTTP/1.1 when no other streams are active."}}),
 	{[], EvHandlerState};
 connect(State=#http_state{socket=Socket, transport=Transport, opts=Opts, version=Version},
 		StreamRef, ReplyTo, Destination=#{host := Host0}, _TunnelInfo, Headers0, InitialFlow0,
@@ -863,13 +863,13 @@ down(#http_state{streams=Streams}) ->
 	end || #stream{ref=Ref} <- Streams].
 
 error_stream_closed(State, StreamRef, ReplyTo) ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), {badstate,
-		"The stream has already been closed."}},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef), {badstate,
+		"The stream has already been closed."}}),
 	ok.
 
 error_stream_not_found(State, StreamRef, ReplyTo) ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), {badstate,
-		"The stream cannot be found."}},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef), {badstate,
+		"The stream cannot be found."}}),
 	ok.
 
 %% Headers information retrieval.
@@ -959,13 +959,13 @@ end_stream(State=#http_state{streams=[_|Tail]}) ->
 
 ws_upgrade(State, StreamRef, ReplyTo, _, _, _, _, _, CookieStore, _, EvHandlerState)
 		when is_list(StreamRef) ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef),
-		{badstate, "The stream is not a tunnel."}},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef),
+		{badstate, "The stream is not a tunnel."}}),
 	{[], CookieStore, EvHandlerState};
 ws_upgrade(State=#http_state{version='HTTP/1.0'},
 		StreamRef, ReplyTo, _, _, _, _, _, CookieStore, _, EvHandlerState) ->
-	ReplyTo ! {gun_error, self(), stream_ref(State, StreamRef), {badstate,
-		"Websocket cannot be used over an HTTP/1.0 connection."}},
+	gun:reply(ReplyTo, {gun_error, self(), stream_ref(State, StreamRef), {badstate,
+		"Websocket cannot be used over an HTTP/1.0 connection."}}),
 	{[], CookieStore, EvHandlerState};
 ws_upgrade(State=#http_state{out=head}, StreamRef, ReplyTo,
 		Host, Port, Path, Headers0, WsOpts, CookieStore0, EvHandler, EvHandlerState0) ->
@@ -1047,7 +1047,7 @@ ws_handshake_end(Buffer,
 	end,
 	%% Inform the user that the upgrade was successful and switch the protocol.
 	RealStreamRef = stream_ref(State, StreamRef),
-	ReplyTo ! {gun_upgrade, self(), RealStreamRef, [<<"websocket">>], Headers},
+	gun:reply(ReplyTo, {gun_upgrade, self(), RealStreamRef, [<<"websocket">>], Headers}),
 	{switch_protocol, {ws, #{
 		stream_ref => RealStreamRef,
 		headers => Headers,

--- a/src/gun_raw.erl
+++ b/src/gun_raw.erl
@@ -57,7 +57,7 @@ init(ReplyTo, Socket, Transport, Opts) ->
 handle(Data, State=#raw_state{ref=StreamRef, reply_to=ReplyTo, flow=Flow0},
 		CookieStore, _, EvHandlerState) ->
 	%% When we take over the entire connection there is no stream reference.
-	ReplyTo ! {gun_data, self(), StreamRef, nofin, Data},
+	gun:reply(ReplyTo, {gun_data, self(), StreamRef, nofin, Data}),
 	Flow = case Flow0 of
 		infinity -> infinity;
 		_ -> Flow0 - 1

--- a/src/gun_socks.erl
+++ b/src/gun_socks.erl
@@ -167,7 +167,7 @@ handle(<<5, 0, 0, Rest0/bits>>, #socks_state{ref=StreamRef, reply_to=ReplyTo, op
 			[NewProtocol0] = maps:get(protocols, Opts, [http]),
 			NewProtocol = gun_protocols:add_stream_ref(NewProtocol0, StreamRef),
 			Protocol = gun_protocols:handler(NewProtocol),
-			ReplyTo ! {gun_tunnel_up, self(), StreamRef, Protocol:name()},
+			gun:reply(ReplyTo, {gun_tunnel_up, self(), StreamRef, Protocol:name()}),
 			[{origin, <<"http">>, NewHost, NewPort, socks5},
 				{switch_protocol, NewProtocol, ReplyTo}]
 	end;

--- a/src/gun_sse_h.erl
+++ b/src/gun_sse_h.erl
@@ -49,12 +49,12 @@ handle(IsFin, Data, State) ->
 handle(IsFin, Data, State=#state{reply_to=ReplyTo, stream_ref=StreamRef, sse_state=SSE0}, Flow) ->
 	case cow_sse:parse(Data, SSE0) of
 		{event, Event, SSE} ->
-			ReplyTo ! {gun_sse, self(), StreamRef, Event},
+			gun:reply(ReplyTo, {gun_sse, self(), StreamRef, Event}),
 			handle(IsFin, <<>>, State#state{sse_state=SSE}, Flow + 1);
 		{more, SSE} ->
 			Inc = case IsFin of
 				fin ->
-					ReplyTo ! {gun_sse, self(), StreamRef, fin},
+					gun:reply(ReplyTo, {gun_sse, self(), StreamRef, fin}),
 					1;
 				_ ->
 					0

--- a/src/gun_tunnel.erl
+++ b/src/gun_tunnel.erl
@@ -125,7 +125,7 @@ init(ReplyTo, OriginSocket, OriginTransport, Opts=#{stream_ref := StreamRef, tun
 					_ = case TunnelProtocol of
 						http -> ok;
 						socks -> ok;
-						_ -> ReplyTo ! {gun_tunnel_up, self(), StreamRef, Proto:name()}
+						_ -> gun:reply(ReplyTo, {gun_tunnel_up, self(), StreamRef, Proto:name()})
 					end,
 					{tunnel, State#tunnel_state{socket=OriginSocket, transport=OriginTransport,
 						protocol=Proto, protocol_state=ProtoState},
@@ -202,7 +202,7 @@ handle_continue(ContinueStreamRef, {gun_tls_proxy, ProxyPid, {ok, Negotiated},
 	case Proto:init(ReplyTo, OriginSocket, gun_tcp_proxy,
 			ProtoOpts#{stream_ref => StreamRef, tunnel_transport => tls}) of
 		{ok, _, ProtoState} ->
-			ReplyTo ! {gun_tunnel_up, self(), StreamRef, Proto:name()},
+			gun:reply(ReplyTo, {gun_tunnel_up, self(), StreamRef, Proto:name()}),
 			{{state, State#tunnel_state{protocol=Proto, protocol_state=ProtoState}},
 				CookieStore, EvHandlerState};
 		Error={error, _} ->

--- a/src/gun_ws_h.erl
+++ b/src/gun_ws_h.erl
@@ -34,11 +34,11 @@ handle({fragment, nofin, _, Payload},
 	{ok, 0, State#state{frag_buffer= << SoFar/binary, Payload/binary >>}};
 handle({fragment, fin, Type, Payload},
 		State=#state{reply_to=ReplyTo, stream_ref=StreamRef, frag_buffer=SoFar}) ->
-	ReplyTo ! {gun_ws, self(), StreamRef, {Type, << SoFar/binary, Payload/binary >>}},
+	gun:reply(ReplyTo, {gun_ws, self(), StreamRef, {Type, << SoFar/binary, Payload/binary >>}}),
 	{ok, 1, State#state{frag_buffer= <<>>}};
 handle(Frame, State=#state{silence_pings=true}) when Frame =:= ping; Frame =:= pong;
 		element(1, Frame) =:= ping; element(1, Frame) =:= pong ->
 	{ok, 0, State};
 handle(Frame, State=#state{reply_to=ReplyTo, stream_ref=StreamRef}) ->
-	ReplyTo ! {gun_ws, self(), StreamRef, Frame},
+	gun:reply(ReplyTo, {gun_ws, self(), StreamRef, Frame}),
 	{ok, 1, State}.


### PR DESCRIPTION
Fixes #314.

In addition to a pid, `reply_to` can be

* a fun called as `Fun(Reply)`
* a tuple `{Fun, Args}` called as `apply(Fun, [Reply | Args])`
* a tuple `{M, F, A}` called as `apply(M, F, [Reply | A])`.