### PR TITLE
Add gun:ping/2,3 for user-initiated ping for HTTP/2

### DIFF
--- a/doc/src/manual/gun.ping.asciidoc
+++ b/doc/src/manual/gun.ping.asciidoc
@@ -1,0 +1,68 @@
+= gun:ping(3)
+
+== Name
+
+gun:ping - Check the health or the round-trip time of a connection
+without sending a request.
+
+== Description
+
+[source,erlang]
+----
+ping(ConnPid)
+    -> ping(ConnPid, #{})
+
+ping(ConnPid, ReqOpts)
+    -> PingRef
+
+ConnPid   :: pid()
+ReqOpts   :: gun:req_opts()
+PingRef   :: gun:stream_ref()
+----
+
+Send a ping.
+
+A ping can be sent to check the health or to measure the
+round-trip time of a connection, without sending a request.
+
+The function `ping/1,2` sends a ping immediately, if the
+protocol supports pings. The server responds with a ping ack.
+A call to `gun:await/2,3` returns `ping_ack` when the ping
+ack has been received from the server.
+
+Currently, explicit ping is supported only for HTTP/2.
+
+== Arguments
+
+ConnPid::
+
+The pid of the Gun connection process.
+
+ReqOpts::
+
+Request options. Only the `reply_to` and `tunnel` options
+can be used.
+
+== Return value
+
+A reference that identifies the ping is returned. This
+reference must be passed in subsequent calls and will be
+received in messages related to this ping.
+
+== Changelog
+
+* *2.x*: Function introduced.
+
+== Examples
+
+.Perform a request
+[source,erlang]
+----
+PingRef = gun:ping(ConnPid).
+ping_ack = gun:await(ConnPid, PingRef).
+----
+
+== See also
+
+link:man:gun(3)[gun(3)],
+link:man:gun:await(3)[gun:await(3)],

--- a/doc/src/manual/gun.ping.asciidoc
+++ b/doc/src/manual/gun.ping.asciidoc
@@ -46,12 +46,12 @@ can be used.
 == Return value
 
 A reference that identifies the ping is returned. This
-reference must be passed in subsequent calls and will be
-received in messages related to this ping.
+reference is included in the notification received when
+a ping ack is received from the server.
 
 == Changelog
 
-* *2.x*: Function introduced.
+* *2.2*: Function introduced.
 
 == Examples
 
@@ -59,7 +59,10 @@ received in messages related to this ping.
 [source,erlang]
 ----
 PingRef = gun:ping(ConnPid).
-ping_ack = gun:await(ConnPid, PingRef).
+receive
+    {gun_notify, ConnPid, ping_ack, PingRef} ->
+        ok
+end.
 ----
 
 == See also

--- a/src/gun.erl
+++ b/src/gun.erl
@@ -800,8 +800,6 @@ await(ServerPid, StreamRef, Timeout, MRef) ->
 			{up, Protocol};
 		{gun_notify, ServerPid, Type, Info} ->
 			{notify, Type, Info};
-		{gun_ping_ack, ServerPid, StreamRef} ->
-			ping_ack;
 		{gun_error, ServerPid, StreamRef, Reason} ->
 			{error, {stream_error, Reason}};
 		{gun_error, ServerPid, Reason} ->
@@ -1389,13 +1387,8 @@ connected_ws_only(Type, Event, State) ->
 %% containing the target URI, instead of separate Host/Port/PathWithQs.
 connected(cast, {ping, ReplyTo, StreamRef},
 		State=#state{protocol=Protocol, protocol_state=ProtoState}) ->
-	case erlang:function_exported(Protocol, ping, 3) of
-		true ->
-			Commands = Protocol:ping(ProtoState, dereference_stream_ref(StreamRef, State), ReplyTo),
-			commands(Commands, State);
-		false ->
-			ReplyTo ! {gun_error, self(), StreamRef, not_supported_for_protocol}
-	end;
+	Commands = Protocol:ping(ProtoState, dereference_stream_ref(StreamRef, State), ReplyTo),
+	commands(Commands, State);
 connected(cast, {headers, ReplyTo, StreamRef, Method, Path, Headers, InitialFlow},
 		State=#state{origin_host=Host, origin_port=Port,
 			protocol=Protocol, protocol_state=ProtoState, cookie_store=CookieStore0,

--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -26,6 +26,7 @@
 -export([closing/4]).
 -export([close/4]).
 -export([keepalive/3]).
+-export([ping/3]).
 -export([headers/12]).
 -export([request/13]).
 -export([data/7]).
@@ -560,6 +561,9 @@ keepalive(#http_state{socket=Socket, transport=Transport, out=head}, _, EvHandle
 	end;
 keepalive(_State, _, EvHandlerState) ->
 	{[], EvHandlerState}.
+
+ping(_State, _PingRef, _ReplyTo) ->
+	{error, unsupported_by_protocol}.
 
 headers(State, StreamRef, ReplyTo, _, _, _, _, _, _, CookieStore, _, EvHandlerState)
 		when is_list(StreamRef) ->

--- a/src/gun_http3.erl
+++ b/src/gun_http3.erl
@@ -487,7 +487,7 @@ close(_Reason, _State, _, EvHandlerState) ->
 keepalive(_State, _, _EvHandlerState) ->
 	error(todo).
 
--spec ping(_, _, _) -> {error, not_implented}.
+-spec ping(_, _, _) -> {error, not_implemented}.
 
 ping(_State, _PingRef, _ReplyTo) ->
 	{error, not_implemented}.

--- a/src/gun_http3.erl
+++ b/src/gun_http3.erl
@@ -28,6 +28,7 @@
 -export([closing/4]).
 -export([close/4]).
 -export([keepalive/3]).
+-export([ping/3]).
 -export([headers/12]).
 -export([request/13]).
 -export([data/7]).
@@ -485,6 +486,11 @@ close(_Reason, _State, _, EvHandlerState) ->
 
 keepalive(_State, _, _EvHandlerState) ->
 	error(todo).
+
+-spec ping(_, _, _) -> {error, not_implented}.
+
+ping(_State, _PingRef, _ReplyTo) ->
+	{error, not_implemented}.
 
 headers(State0=#http3_state{conn=Conn, transport=Transport,
 		http3_machine=HTTP3Machine0}, StreamRef, ReplyTo, Method, Host, Port,

--- a/src/gun_raw.erl
+++ b/src/gun_raw.erl
@@ -23,6 +23,7 @@
 -export([update_flow/4]).
 -export([closing/4]).
 -export([close/4]).
+-export([ping/3]).
 -export([data/7]).
 -export([down/1]).
 
@@ -83,6 +84,9 @@ closing(_, _, _, EvHandlerState) ->
 
 close(_, _, _, EvHandlerState) ->
 	EvHandlerState.
+
+ping(_State, _PingRef, _ReplyTo) ->
+	{error, unsupported_by_protocol}.
 
 %% @todo Initiate closing on IsFin=fin.
 data(#raw_state{ref=StreamRef, socket=Socket, transport=Transport}, StreamRef,

--- a/src/gun_socks.erl
+++ b/src/gun_socks.erl
@@ -23,6 +23,7 @@
 -export([handle/5]).
 -export([closing/4]).
 -export([close/4]).
+-export([ping/3]).
 %% @todo down
 
 -record(socks_state, {
@@ -205,3 +206,6 @@ closing(_, _, _, EvHandlerState) ->
 
 close(_, _, _, EvHandlerState) ->
 	EvHandlerState.
+
+ping(_State, _PingRef, _ReplyTo) ->
+	{error, unsupported_by_protocol}.

--- a/src/gun_ws.erl
+++ b/src/gun_ws.erl
@@ -28,6 +28,7 @@
 -export([closing/4]).
 -export([close/4]).
 -export([keepalive/3]).
+-export([ping/3]).
 -export([ws_send/6]).
 -export([down/1]).
 
@@ -300,6 +301,9 @@ close(_, _, _, EvHandlerState) ->
 
 keepalive(State=#ws_state{reply_to=ReplyTo}, EvHandler, EvHandlerState0) ->
 	send(ping, State, ReplyTo, EvHandler, EvHandlerState0).
+
+ping(_State, _PingRef, _ReplyTo) ->
+	{error, not_implemented}.
 
 %% Send one frame.
 send(Frame, State=#ws_state{stream_ref=StreamRef,

--- a/test/rfc7540_SUITE.erl
+++ b/test/rfc7540_SUITE.erl
@@ -492,7 +492,12 @@ user_initiated_ping(_) ->
 	{ok, http2} = gun:await_up(Pid),
 	handshake_completed = receive_from(OriginPid),
 	PingRef = gun:ping(Pid),
-	ping_ack = gun:await(Pid, PingRef, 1000),
+	receive
+		{gun_notify, Pid, ping_ack, PingRef} ->
+			ok
+	after 1000 ->
+		error(timeout)
+	end,
 	gun:close(Pid).
 
 do_ping_ack_loop_fun() ->


### PR DESCRIPTION
This feature allows a user to explicitly send a ping frame and receive a ping ack. The use case is to test the latency and health of existing long-lived API connections using some admin tool.

A request, such as OPTIONS or HEAD, can also be used for this purpose, but it may be handled differently by middleware.

This PR implements it only for HTTP/2, which is the use case we have. For other protocols, an error tuple is sent to the reply-to process.

This use case is mentioned in RFC 7540, section 6.7:

    The PING frame (type=0x6) is a mechanism for measuring a minimal
    round-trip time from the sender, as well as determining whether an
    idle connection is still functional.

Section 8.1.4:

    The PING frame allows a client to safely test whether a connection is
    still active without sending a request.
