### PR TITLE
Fix testing with rebar

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,3 +2,4 @@
 {cowlib,".*",{git,"https://github.com/ninenines/cowlib",{tag,"2.15.0"}}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.
+{ct_opts, [{ct_hooks, [gun_ct_hook]}]}.


### PR DESCRIPTION
We're using Rebar3 for everything from building to testing - fetching deps, preparing pre-built steps, building, and testing. Unfortunately your rebar.config file lacks ct_opts parameters so it fails the tests. This patch fixes that (and doesn't change anything for erlang.mk-based workflows).