### PR TITLE
Configurable lookup strategy

### DIFF
--- a/src/gun_pool.erl
+++ b/src/gun_pool.erl
@@ -102,7 +102,8 @@
 	conn_opts => gun:opts(),
 	scope => any(),
 	setup_fun => {fun((pid(), setup_msg(), any()) -> any()), any()},
-	size => non_neg_integer()
+	size => non_neg_integer(),
+	selection_strategy => random | least_loaded
 }.
 -export_type([opts/0]).
 
@@ -147,10 +148,12 @@
 	host :: inet:hostname() | inet:ip_address(),
 	port :: inet:port_number(),
 	opts :: opts(),
-	table :: ets:tid(),
 	conns :: #{pid() => down | {setup, any()} | {up, http | http2 | ws | raw, map()}},
 	conns_meta = #{} :: meta(),
-	await_up = [] :: [{pid(), any()}]
+	await_up = [] :: [{pid(), any()}],
+	lookup :: #{strategy := random, table := ets:tid()}
+	        | #{strategy := least_loaded, available := gb_trees:tree(),
+	            stream_counts := #{pid() => non_neg_integer()}, up_count := non_neg_integer()}
 }).
 
 %% Pool management.
@@ -488,17 +491,22 @@ ws_send(Frames, WsSendOpts=#{authority := Authority}) ->
 %%
 %% The pool manager installs an event handler into each connection.
 %% The event handler is responsible for counting the number of
-%% active streams. It updates the gun_pooled_conns ets table
-%% whenever a stream begins or ends.
+%% active streams. For the random strategy it writes stream counts
+%% directly to the gun_pooled_conns ETS table (which is public).
+%% For the least_loaded strategy it casts {stream_count, ConnPid, NewCount}
+%% to the manager process, which updates the gb_tree index and stream
+%% counts map accordingly.
 %%
 %% A connection is deemed suitable if it is possible to open new
 %% streams. How many streams can be open at any one time depends
 %% on the protocol. For HTTP/2 the manager process keeps track of
 %% the connection's settings to know the maximum. For non-stream
-%% based protocols, there is no limit.
+%% based protocols there is no limit.
 %%
-%% The connection to be used is otherwise chosen randomly. The
-%% first connection that is suitable is returned. There is no
+%% For the random strategy, connections are shuffled and the first
+%% suitable one is returned. For the least_loaded strategy the
+%% gb_tree is traversed in ascending order of stream count, returning
+%% the least loaded connection that still has capacity. There is no
 %% need to "give back" the connection to the manager.
 
 %% @todo
@@ -513,10 +521,17 @@ start_link(Host, Port, Opts) ->
 init({Host, Port, Opts}) ->
 	process_flag(trap_exit, true),
 	true = ets:insert_new(gun_pools, {gun_pools_key(Host, Port, Opts), self()}),
-	Tid = ets:new(gun_pooled_conns, [ordered_set, public]),
 	Size = maps:get(size, Opts, 8),
 	%% @todo Only start processes in static mode.
-	ConnOpts = conn_opts(Tid, Opts),
+	Lookup = case maps:get(selection_strategy, Opts, random) of
+		random ->
+			Tid = ets:new(gun_pooled_conns, [ordered_set, public]),
+			#{strategy => random, table => Tid};
+		least_loaded ->
+		#{strategy => least_loaded, available => gb_trees:empty(),
+			stream_counts => #{}, up_count => 0, manager_pid => self()}
+	end,
+	ConnOpts = conn_opts(Lookup, Opts),
 	Conns = maps:from_list([begin
 		{ok, ConnPid} = gun:open(Host, Port, ConnOpts),
 		_ = monitor(process, ConnPid),
@@ -526,7 +541,7 @@ init({Host, Port, Opts}) ->
 		host=Host,
 		port=Port,
 		opts=Opts,
-		table=Tid,
+		lookup=Lookup,
 		conns=Conns
 	},
 	%% If Size is 0 then we can never be operational.
@@ -538,13 +553,28 @@ gun_pools_key(Host, Port, Opts) ->
 	Scope = maps:get(scope, Opts, default),
 	{Scope, iolist_to_binary(Authority)}.
 
-conn_opts(Tid, Opts) ->
+conn_opts(#{strategy := random, table := Tid}, Opts) ->
 	ConnOpts = maps:get(conn_opts, Opts, #{}),
 	EventHandlerState = maps:with([event_handler], ConnOpts),
 	H2Opts = maps:get(http2_opts, ConnOpts, #{}),
 	ConnOpts#{
 		event_handler => {gun_pool_events_h, EventHandlerState#{
 			table => Tid
+		}},
+		http2_opts => H2Opts#{
+			notify_settings_changed => true
+		}
+	};
+conn_opts(#{strategy := least_loaded, manager_pid := ManagerPid}, Opts) ->
+	ConnOpts = maps:get(conn_opts, Opts, #{}),
+	EventHandlerState = maps:with([event_handler], ConnOpts),
+	H2Opts = maps:get(http2_opts, ConnOpts, #{}),
+	%% @todo Notify the pool process of stream count changes via messages
+	%% instead of writing to an ETS table.
+	ConnOpts#{
+		event_handler => {gun_pool_events_h, EventHandlerState#{
+			manager => ManagerPid,
+			stream_count => 0
 		}},
 		http2_opts => H2Opts#{
 			notify_settings_changed => true
@@ -584,7 +614,7 @@ setup_fun(_) ->
 		{up, Protocol, #{}}
 	end, undefined}.
 
-degraded_setup(ConnPid, Msg, StateData0=#state{conns=Conns, conns_meta=ConnsMeta,
+degraded_setup(ConnPid, Msg, StateData0=#state{lookup=#{strategy := random}, conns=Conns, conns_meta=ConnsMeta,
 		await_up=AwaitUp}, SetupFun, SetupState0) ->
 	case SetupFun(ConnPid, Msg, SetupState0) of
 		Setup={setup, _SetupState} ->
@@ -605,11 +635,40 @@ degraded_setup(ConnPid, Msg, StateData0=#state{conns=Conns, conns_meta=ConnsMeta
 			end
 	end.
 
-is_degraded(#state{conns=Conns0}) ->
+degraded_setup(ConnPid, Msg, StateData0=#state{conns=Conns, conns_meta=ConnsMeta,
+		lookup=#{available := Available, stream_counts := StreamCounts, up_count := UpCount} = Lookup,
+		await_up=AwaitUp}, SetupFun, SetupState0) ->
+	case SetupFun(ConnPid, Msg, SetupState0) of
+		Setup={setup, _SetupState} ->
+			StateData = StateData0#state{conns=Conns#{ConnPid => Setup}},
+			{keep_state, StateData};
+		%% The Meta is different from Settings. It allows passing around
+		%% Websocket or tunnel stream refs.
+		{up, Protocol, Meta} ->
+			Settings = #{},
+			StateData = StateData0#state{
+				conns=Conns#{ConnPid => {up, Protocol, Settings}},
+				conns_meta=ConnsMeta#{ConnPid => Meta},
+				lookup=Lookup#{
+					available => gb_trees:insert({0, ConnPid}, ConnPid, Available),
+					stream_counts => StreamCounts#{ConnPid => 0},
+					up_count => UpCount + 1
+				}
+			},
+			case is_degraded(StateData) of
+				true -> {keep_state, StateData};
+				false -> {next_state, operational, StateData#state{await_up=[]},
+					[{reply, ReplyTo, ok} || ReplyTo <- AwaitUp]}
+			end
+	end.
+
+is_degraded(#state{lookup=#{strategy := random}, conns=Conns0}) ->
 	Conns = maps:to_list(Conns0),
 	Len = length(Conns),
 	Ups = [up || {_, {up, _, _}} <- Conns],
-	Len =/= length(Ups).
+	Len =/= length(Ups);
+is_degraded(#state{lookup=#{strategy := least_loaded, up_count := UpCount}, conns=Conns0}) ->
+	UpCount =/= map_size(Conns0).
 
 operational(Type, Event, StateData) ->
 	handle_common(Type, Event, ?FUNCTION_NAME, StateData).
@@ -623,16 +682,47 @@ handle_common({call, From}, {checkout, _ReqOpts}, _,
 			Meta = maps:get(ConnPid, ConnsMeta, #{}),
 			{keep_state_and_data, {reply, From, {ConnPid, Meta}}}
 	end;
+handle_common(cast, {stream_count, ConnPid, NewCount}, _,
+		StateData=#state{lookup=#{available := Available0, stream_counts := StreamCounts} = Lookup}) ->
+	case maps:find(ConnPid, StreamCounts) of
+		{ok, OldCount} ->
+			Available1 = gb_trees:delete({OldCount, ConnPid}, Available0),
+			Available = gb_trees:insert({NewCount, ConnPid}, ConnPid, Available1),
+			{keep_state, StateData#state{
+				lookup=Lookup#{
+					available => Available,
+					stream_counts => StreamCounts#{ConnPid => NewCount}
+				}
+			}};
+		error ->
+			%% Connection not tracked (down or removed), ignore.
+			keep_state_and_data
+	end;
 handle_common(info, {gun_notify, ConnPid, settings_changed, Settings}, _, StateData=#state{conns=Conns}) ->
 	%% Assert that the state is correct.
 	{up, http2, _} = maps:get(ConnPid, Conns),
 	{keep_state, StateData#state{conns=Conns#{ConnPid => {up, http2, Settings}}}};
-handle_common(info, {gun_down, ConnPid, Protocol, _Reason, _KilledStreams}, _, StateData=#state{conns=Conns}) ->
+handle_common(info, {gun_down, ConnPid, Protocol, _Reason, _KilledStreams}, _,
+		StateData=#state{lookup=#{strategy := random}, conns=Conns}) ->
 	{up, Protocol, _} = maps:get(ConnPid, Conns),
 	{next_state, degraded, StateData#state{conns=Conns#{ConnPid => down}}};
+handle_common(info, {gun_down, ConnPid, Protocol, _Reason, _KilledStreams}, _,
+		StateData=#state{lookup=#{strategy := least_loaded, available := Available,
+				stream_counts := StreamCounts, up_count := UpCount} = Lookup, conns=Conns}) ->
+	{up, Protocol, _} = maps:get(ConnPid, Conns),
+	OldCount = maps:get(ConnPid, StreamCounts, 0),
+	{next_state, degraded, StateData#state{
+		conns=Conns#{ConnPid => down},
+		lookup=Lookup#{
+			available => gb_trees:delete({OldCount, ConnPid}, Available),
+			stream_counts => maps:remove(ConnPid, StreamCounts),
+			up_count => UpCount - 1
+		}
+	}};
 %% @todo We do not want to reconnect automatically when the pool is dynamic.
 handle_common(info, {'DOWN', _MRef, process, ConnPid0, Reason}, _,
-		StateData=#state{host=Host, port=Port, opts=Opts, table=Tid, conns=Conns0, conns_meta=ConnsMeta0}) ->
+		StateData=#state{lookup=#{strategy := random} = Lookup, host=Host, port=Port, opts=Opts,
+				conns=Conns0, conns_meta=ConnsMeta0}) ->
 	Conns = maps:remove(ConnPid0, Conns0),
 	ConnsMeta = maps:remove(ConnPid0, ConnsMeta0),
 	case Reason of
@@ -641,19 +731,51 @@ handle_common(info, {'DOWN', _MRef, process, ConnPid0, Reason}, _,
 		badarg ->
 			{next_state, degraded, StateData#state{conns=Conns, conns_meta=ConnsMeta}};
 		_ ->
-			ConnOpts = conn_opts(Tid, Opts),
+			ConnOpts = conn_opts(Lookup, Opts),
 			{ok, ConnPid} = gun:open(Host, Port, ConnOpts),
 			_ = monitor(process, ConnPid),
 			{next_state, degraded, StateData#state{conns=Conns#{ConnPid => down}, conns_meta=ConnsMeta}}
 	end;
+handle_common(info, {'DOWN', _MRef, process, ConnPid0, Reason}, _,
+		StateData=#state{lookup=#{strategy := least_loaded, available := Available0,
+				stream_counts := StreamCounts0, up_count := UpCount0} = Lookup,
+				host=Host, port=Port, opts=Opts, conns=Conns0, conns_meta=ConnsMeta0}) ->
+	WasUp = case maps:get(ConnPid0, Conns0) of
+		{up, _, _} -> true;
+		_ -> false
+	end,
+	OldCount = maps:get(ConnPid0, StreamCounts0, 0),
+	Conns = maps:remove(ConnPid0, Conns0),
+	ConnsMeta = maps:remove(ConnPid0, ConnsMeta0),
+	Available = case WasUp of
+		true -> gb_trees:delete({OldCount, ConnPid0}, Available0);
+		false -> Available0
+	end,
+	StreamCounts = maps:remove(ConnPid0, StreamCounts0),
+	UpCount = case WasUp of true -> UpCount0 - 1; false -> UpCount0 end,
+	StateData1 = StateData#state{
+		conns=Conns, conns_meta=ConnsMeta,
+		lookup=Lookup#{available => Available, stream_counts => StreamCounts, up_count => UpCount}
+	},
+	case Reason of
+		%% The process is down because of a configuration error.
+		%% Do NOT attempt to reconnect, leave the pool in a degraded state.
+		badarg ->
+			{next_state, degraded, StateData1};
+		_ ->
+			ConnOpts = conn_opts(Lookup, Opts),
+			{ok, ConnPid} = gun:open(Host, Port, ConnOpts),
+			_ = monitor(process, ConnPid),
+			{next_state, degraded, StateData1#state{conns=Conns#{ConnPid => down}}}
+	end;
 handle_common({call, From}, info, StateName, #state{host=Host, port=Port,
-		opts=Opts, table=Tid, conns=Conns, conns_meta=ConnsMeta}) ->
+		opts=Opts, lookup=Lookup, conns=Conns, conns_meta=ConnsMeta}) ->
 	{keep_state_and_data, {reply, From, {StateName, #{
 		%% @todo Not sure whether all of this should be documented. Maybe not ConnsMeta for now?
 		host => Host,
 		port => Port,
 		opts => Opts,
-		table => Tid,
+		lookup => Lookup,
 		conns => Conns,
 		conns_meta => ConnsMeta
 	}}}};
@@ -672,13 +794,17 @@ handle_common(Type, Event, StateName, StateData) ->
 %% HTTP/2 we look into the protocol settings. The
 %% current number of streams is maintained by the
 %% event handler gun_pool_events_h.
-find_available_connection(#state{table=Tid, conns=Conns}) ->
+find_available_connection(#state{lookup=#{strategy := random, table := Tid}, conns=Conns}) ->
 	I = lists:sort([{rand:uniform(), K} || K <- maps:keys(Conns)]),
-	find_available_connection(I, Conns, Tid).
+	find_available_connection_random(I, Conns, Tid);
+find_available_connection(#state{lookup=#{strategy := least_loaded, available := Available,
+		stream_counts := StreamCounts}, conns=Conns}) ->
+	%% @todo Use Available gb_tree to pick the least-loaded connection in O(log n).
+	find_available_connection_least_loaded(Available, Conns).
 
-find_available_connection([], _, _) ->
+find_available_connection_random([], _, _) ->
 	none;
-find_available_connection([{_, ConnPid}|I], Conns, Tid) ->
+find_available_connection_random([{_, ConnPid}|I], Conns, Tid) ->
 	case maps:get(ConnPid, Conns) of
 		{up, Protocol, Settings} ->
 			MaxStreams = max_streams(Protocol, Settings),
@@ -690,12 +816,32 @@ find_available_connection([{_, ConnPid}|I], Conns, Tid) ->
 			end,
 			if
 				CurrentStreams + 1 > MaxStreams ->
-					find_available_connection(I, Conns, Tid);
+					find_available_connection_random(I, Conns, Tid);
 				true ->
 					ConnPid
 			end;
 		_ ->
-			find_available_connection(I, Conns, Tid)
+			find_available_connection_random(I, Conns, Tid)
+	end.
+
+find_available_connection_least_loaded(Available, Conns) ->
+	find_available_connection_iter(gb_trees:iterator(Available), Conns).
+
+find_available_connection_iter(Iter0, Conns) ->
+	case gb_trees:next(Iter0) of
+		none ->
+			none;
+		{{Count, ConnPid}, _, Iter} ->
+			case maps:get(ConnPid, Conns) of
+				{up, Protocol, Settings} ->
+					MaxStreams = max_streams(Protocol, Settings),
+					case Count < MaxStreams of
+						true -> ConnPid;
+						false -> find_available_connection_iter(Iter, Conns)
+					end;
+				_ ->
+					find_available_connection_iter(Iter, Conns)
+			end
 	end.
 
 max_streams(http, _) ->

--- a/src/gun_pool.erl
+++ b/src/gun_pool.erl
@@ -628,13 +628,12 @@ degraded_setup(ConnPid, Msg, StateData0=#state{lookup=#{strategy := random}, con
 				conns=Conns#{ConnPid => {up, Protocol, Settings}},
 				conns_meta=ConnsMeta#{ConnPid => Meta}
 			},
-			case is_degraded(StateData) of
-				true -> {keep_state, StateData};
-				false -> {next_state, operational, StateData#state{await_up=[]},
-					[{reply, ReplyTo, ok} || ReplyTo <- AwaitUp]}
-			end
-	end.
-
+		case is_degraded(StateData) of
+			true -> {keep_state, StateData};
+			false -> {next_state, operational, StateData#state{await_up=[]},
+				[{reply, ReplyTo, ok} || ReplyTo <- AwaitUp]}
+		end
+	end;
 degraded_setup(ConnPid, Msg, StateData0=#state{conns=Conns, conns_meta=ConnsMeta,
 		lookup=#{available := Available, stream_counts := StreamCounts, up_count := UpCount} = Lookup,
 		await_up=AwaitUp}, SetupFun, SetupState0) ->
@@ -797,8 +796,8 @@ handle_common(Type, Event, StateName, StateData) ->
 find_available_connection(#state{lookup=#{strategy := random, table := Tid}, conns=Conns}) ->
 	I = lists:sort([{rand:uniform(), K} || K <- maps:keys(Conns)]),
 	find_available_connection_random(I, Conns, Tid);
-find_available_connection(#state{lookup=#{strategy := least_loaded, available := Available,
-		stream_counts := StreamCounts}, conns=Conns}) ->
+find_available_connection(#state{lookup=#{strategy := least_loaded, available := Available},
+		conns=Conns}) ->
 	%% @todo Use Available gb_tree to pick the least-loaded connection in O(log n).
 	find_available_connection_least_loaded(Available, Conns).
 

--- a/src/gun_pool_events_h.erl
+++ b/src/gun_pool_events_h.erl
@@ -68,6 +68,13 @@ request_start(Event=#{stream_ref := StreamRef}, State=#{table := Tid}) ->
 	_ = ets:update_counter(Tid, self(), +1, {self(), 0}),
 	propagate(Event, State#{
 		StreamRef => {nofin, nofin}
+	}, ?FUNCTION_NAME);
+request_start(Event=#{stream_ref := StreamRef}, State=#{manager := Manager, stream_count := Count}) ->
+	NewCount = Count + 1,
+	gen_statem:cast(Manager, {stream_count, self(), NewCount}),
+	propagate(Event, State#{
+		stream_count => NewCount,
+		StreamRef => {nofin, nofin}
 	}, ?FUNCTION_NAME).
 
 request_headers(Event, State) ->
@@ -78,6 +85,16 @@ request_end(Event=#{stream_ref := StreamRef}, State0=#{table := Tid}) ->
 		#{StreamRef := {nofin, fin}} ->
 			_ = ets:update_counter(Tid, self(), -1),
 			maps:remove(StreamRef, State0);
+		#{StreamRef := {nofin, IsFin}} ->
+			State0#{StreamRef => {fin, IsFin}}
+	end,
+	propagate(Event, State, ?FUNCTION_NAME);
+request_end(Event=#{stream_ref := StreamRef}, State0=#{manager := Manager, stream_count := Count}) ->
+	State = case State0 of
+		#{StreamRef := {nofin, fin}} ->
+			NewCount = Count - 1,
+			gen_statem:cast(Manager, {stream_count, self(), NewCount}),
+			maps:remove(StreamRef, State0#{stream_count => NewCount});
 		#{StreamRef := {nofin, IsFin}} ->
 			State0#{StreamRef => {fin, IsFin}}
 	end,
@@ -106,6 +123,16 @@ response_end(Event=#{stream_ref := StreamRef}, State0=#{table := Tid}) ->
 		#{StreamRef := {fin, nofin}} ->
 			_ = ets:update_counter(Tid, self(), -1),
 			maps:remove(StreamRef, State0);
+		#{StreamRef := {IsFin, nofin}} ->
+			State0#{StreamRef => {IsFin, fin}}
+	end,
+	propagate(Event, State, ?FUNCTION_NAME);
+response_end(Event=#{stream_ref := StreamRef}, State0=#{manager := Manager, stream_count := Count}) ->
+	State = case State0 of
+		#{StreamRef := {fin, nofin}} ->
+			NewCount = Count - 1,
+			gen_statem:cast(Manager, {stream_count, self(), NewCount}),
+			maps:remove(StreamRef, State0#{stream_count => NewCount});
 		#{StreamRef := {IsFin, nofin}} ->
 			State0#{StreamRef => {IsFin, fin}}
 	end,
@@ -145,7 +172,9 @@ disconnect(Event, State=#{table := Tid}) ->
 	catch _:_ ->
 		ok
 	end,
-	propagate(Event, maps:with([event_handler, table], State), ?FUNCTION_NAME).
+	propagate(Event, maps:with([event_handler, table], State), ?FUNCTION_NAME);
+disconnect(Event, State=#{manager := _Manager, stream_count := _Count}) ->
+	propagate(Event, maps:with([event_handler, manager, stream_count], State#{stream_count => 0}), ?FUNCTION_NAME).
 
 terminate(Event, State) ->
 	propagate(Event, State, ?FUNCTION_NAME).

--- a/test/pool_SUITE.erl
+++ b/test/pool_SUITE.erl
@@ -21,7 +21,28 @@
 -import(gun_test, [receive_from/1]).
 
 all() ->
-	ct_helper:all(?MODULE).
+	[{group, random}, {group, least_loaded}].
+
+groups() ->
+	Tests = [
+		hello_pool_h1,
+		hello_pool_h2,
+		hello_pool_ws,
+		max_streams_h1,
+		max_streams_h1_retry,
+		max_streams_h2_size_1,
+		max_streams_h2_size_1_retry,
+		max_streams_h2_size_2,
+		max_streams_h2_size_2_retry,
+		kill_restart_h1,
+		kill_restart_h2,
+		reconnect_h1,
+		reconnect_h2,
+		stop_pool,
+		degraded_configuration_error
+	],
+	[{random, [], Tests},
+	 {least_loaded, [], Tests ++ [least_loaded_routing]}].
 
 init_per_suite(Config) ->
 	{ok, _} = cowboy:start_clear({?MODULE, tcp}, [], do_proto_opts()),
@@ -29,12 +50,26 @@ init_per_suite(Config) ->
 	[{port, Port}|Config].
 
 end_per_suite(_) ->
+	%% Stop listeners started by individual test cases in both groups.
 	ExtraListeners = [
-		max_streams_h2_size_1,
-		max_streams_h2_size_2,
-		reconnect_h1
+		max_streams_h2_size_1_random,
+		max_streams_h2_size_1_retry_random,
+		max_streams_h2_size_2_random,
+		max_streams_h2_size_2_retry_random,
+		reconnect_h1_random,
+		max_streams_h2_size_1_least_loaded,
+		max_streams_h2_size_1_retry_least_loaded,
+		max_streams_h2_size_2_least_loaded,
+		max_streams_h2_size_2_retry_least_loaded,
+		reconnect_h1_least_loaded
 	],
 	_ = [cowboy:stop_listener(Listener) || Listener <- ExtraListeners],
+	ok.
+
+init_per_group(GroupName, Config) ->
+	[{selection_strategy, GroupName} | Config].
+
+end_per_group(_, _) ->
 	ok.
 
 do_proto_opts() ->
@@ -47,19 +82,30 @@ do_proto_opts() ->
 		env => #{dispatch => cowboy_router:compile([{'_', Routes}])}
 	}.
 
+%% Builds a per-group listener name to avoid collisions between group runs.
+listener_name(FuncName, Config) ->
+	Strategy = config(selection_strategy, Config),
+	list_to_atom(atom_to_list(FuncName) ++ "_" ++ atom_to_list(Strategy)).
+
+%% Builds a per-group scope to avoid ETS key collisions between group runs.
+scope(FuncName, Config) ->
+	{config(selection_strategy, Config), FuncName}.
+
 %% Tests.
 
 hello_pool_h1(Config) ->
 	doc("Confirm the pool can be used for HTTP/1.1 connections."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http]},
-		scope => ?FUNCTION_NAME
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy
 	}),
 	gun_pool:await_up(ManagerPid),
 	Streams = [{async, _} = gun_pool:get("/",
 		#{<<"host">> => ["localhost:", integer_to_binary(Port)]},
-		#{scope => ?FUNCTION_NAME}
+		#{scope => scope(?FUNCTION_NAME, Config)}
 	) || _ <- lists:seq(1, 8)],
 	_ = [begin
 		{response, nofin, 200, _} = gun_pool:await(StreamRef),
@@ -69,14 +115,16 @@ hello_pool_h1(Config) ->
 hello_pool_h2(Config) ->
 	doc("Confirm the pool can be used for HTTP/2 connections."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http2]},
-		scope => ?FUNCTION_NAME
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy
 	}),
 	gun_pool:await_up(ManagerPid),
 	Streams = [{async, _} = gun_pool:get("/",
 		#{<<"host">> => ["localhost:", integer_to_binary(Port)]},
-		#{scope => ?FUNCTION_NAME}
+		#{scope => scope(?FUNCTION_NAME, Config)}
 	) || _ <- lists:seq(1, 800)],
 	_ = [begin
 		{response, nofin, 200, _} = gun_pool:await(StreamRef),
@@ -86,6 +134,7 @@ hello_pool_h2(Config) ->
 hello_pool_ws(Config) ->
 	doc("Confirm the pool can be used for HTTP/1.1 connections upgraded to Websocket."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{
 			protocols => [http],
@@ -94,7 +143,8 @@ hello_pool_ws(Config) ->
 				user_opts => self()
 			}
 		},
-		scope => ?FUNCTION_NAME,
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy,
 		setup_fun => {fun
 			(ConnPid, {gun_up, _, http}, SetupState) ->
 				_ = gun:ws_upgrade(ConnPid, "/ws"),
@@ -109,7 +159,7 @@ hello_pool_ws(Config) ->
 	gun_pool:await_up(ManagerPid),
 	_ = [gun_pool:ws_send({text, <<"Hello world!">>}, #{
 		authority => ["localhost:", integer_to_binary(Port)],
-		scope => ?FUNCTION_NAME
+		scope => scope(?FUNCTION_NAME, Config)
 	}) || _ <- lists:seq(1, 8)],
 	%% The pool_ws_handler module sends frames back to us.
 	_ = [receive
@@ -121,51 +171,58 @@ max_streams_h1(Config) ->
 	doc("Confirm requests are rejected when the maximum number "
 		"of streams is reached for HTTP/1.1 connections."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http]},
-		scope => ?FUNCTION_NAME,
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy,
 		size => 1
 	}),
 	gun_pool:await_up(ManagerPid),
 	{async, _} = gun_pool:get("/delay",
-		#{<<"host">> => Authority}, #{scope => ?FUNCTION_NAME}),
+		#{<<"host">> => Authority}, #{scope => scope(?FUNCTION_NAME, Config)}),
 	timer:sleep(500),
 	{error, no_connection_available, _} = gun_pool:get("/delay",
-		#{<<"host">> => Authority}, #{scope => ?FUNCTION_NAME}).
+		#{<<"host">> => Authority}, #{scope => scope(?FUNCTION_NAME, Config)}).
 
 max_streams_h1_retry(Config) ->
 	doc("Confirm connection checkout is retried when the maximum number "
 		"of streams is reached for HTTP/1.1 connections."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http]},
-		scope => ?FUNCTION_NAME,
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy,
 		size => 1
 	}),
 	gun_pool:await_up(ManagerPid),
 	{async, _} = gun_pool:get("/delay",
-		#{<<"host">> => Authority}, #{scope => ?FUNCTION_NAME}),
+		#{<<"host">> => Authority}, #{scope => scope(?FUNCTION_NAME, Config)}),
 	timer:sleep(500),
 	{error, no_connection_available, _} = gun_pool:get("/delay",
-		#{<<"host">> => Authority}, #{scope => ?FUNCTION_NAME}),
+		#{<<"host">> => Authority}, #{scope => scope(?FUNCTION_NAME, Config)}),
 	{async, _} = gun_pool:get("/delay", #{<<"host">> => Authority}, #{
 		checkout_retry => [100, 500, 500, 500, 500, 500, 500],
-		scope => ?FUNCTION_NAME
+		scope => scope(?FUNCTION_NAME, Config)
 	}).
 
-max_streams_h2_size_1(_) ->
+max_streams_h2_size_1(Config) ->
 	doc("Confirm requests are rejected when the maximum number "
 		"of streams is reached for HTTP/2 connections."),
+	Strategy = config(selection_strategy, Config),
+	Listener = listener_name(?FUNCTION_NAME, Config),
 	ProtoOpts = do_proto_opts(),
-	{ok, _} = cowboy:start_clear(?FUNCTION_NAME, [], ProtoOpts#{
+	{ok, _} = cowboy:start_clear(Listener, [], ProtoOpts#{
 		max_concurrent_streams => 5
 	}),
-	Port = ranch:get_port(?FUNCTION_NAME),
+	Port = ranch:get_port(Listener),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http2]},
+		selection_strategy => Strategy,
 		size => 1
 	}),
 	gun_pool:await_up(ManagerPid),
@@ -173,17 +230,20 @@ max_streams_h2_size_1(_) ->
 	timer:sleep(500),
 	{error, no_connection_available, _} = gun_pool:get("/delay", #{<<"host">> => Authority}).
 
-max_streams_h2_size_1_retry(_) ->
+max_streams_h2_size_1_retry(Config) ->
 	doc("Confirm connection checkout is retried when the maximum number "
 		"of streams is reached for HTTP/2 connections."),
+	Strategy = config(selection_strategy, Config),
+	Listener = listener_name(?FUNCTION_NAME, Config),
 	ProtoOpts = do_proto_opts(),
-	{ok, _} = cowboy:start_clear(?FUNCTION_NAME, [], ProtoOpts#{
+	{ok, _} = cowboy:start_clear(Listener, [], ProtoOpts#{
 		max_concurrent_streams => 5
 	}),
-	Port = ranch:get_port(?FUNCTION_NAME),
+	Port = ranch:get_port(Listener),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http2]},
+		selection_strategy => Strategy,
 		size => 1
 	}),
 	gun_pool:await_up(ManagerPid),
@@ -194,17 +254,20 @@ max_streams_h2_size_1_retry(_) ->
 		checkout_retry => [100, 500, 500, 500, 500, 500, 500]
 	}).
 
-max_streams_h2_size_2(_) ->
+max_streams_h2_size_2(Config) ->
 	doc("Confirm requests are rejected when the maximum number "
 		"of streams is reached for HTTP/2 connections."),
+	Strategy = config(selection_strategy, Config),
+	Listener = listener_name(?FUNCTION_NAME, Config),
 	ProtoOpts = do_proto_opts(),
-	{ok, _} = cowboy:start_clear(?FUNCTION_NAME, [], ProtoOpts#{
+	{ok, _} = cowboy:start_clear(Listener, [], ProtoOpts#{
 		max_concurrent_streams => 5
 	}),
-	Port = ranch:get_port(?FUNCTION_NAME),
+	Port = ranch:get_port(Listener),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http2]},
+		selection_strategy => Strategy,
 		size => 2
 	}),
 	gun_pool:await_up(ManagerPid),
@@ -217,17 +280,20 @@ max_streams_h2_size_2(_) ->
 	timer:sleep(500),
 	{error, no_connection_available, _} = gun_pool:get("/delay", #{<<"host">> => Authority}).
 
-max_streams_h2_size_2_retry(_) ->
+max_streams_h2_size_2_retry(Config) ->
 	doc("Confirm connection checkout is retried when the maximum number "
 		"of streams is reached for HTTP/2 connections."),
+	Strategy = config(selection_strategy, Config),
+	Listener = listener_name(?FUNCTION_NAME, Config),
 	ProtoOpts = do_proto_opts(),
-	{ok, _} = cowboy:start_clear(?FUNCTION_NAME, [], ProtoOpts#{
+	{ok, _} = cowboy:start_clear(Listener, [], ProtoOpts#{
 		max_concurrent_streams => 5
 	}),
-	Port = ranch:get_port(?FUNCTION_NAME),
+	Port = ranch:get_port(Listener),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http2]},
+		selection_strategy => Strategy,
 		size => 2
 	}),
 	gun_pool:await_up(ManagerPid),
@@ -247,15 +313,17 @@ kill_restart_h1(Config) ->
 	doc("Confirm the Gun process is restarted and the pool operational "
 		"after an HTTP/1.1 Gun process has crashed."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http]},
-		scope => ?FUNCTION_NAME
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy
 	}),
 	gun_pool:await_up(ManagerPid),
 	Streams1 = [{async, _} = gun_pool:get("/",
 		#{<<"host">> => Authority},
-		#{scope => ?FUNCTION_NAME}
+		#{scope => scope(?FUNCTION_NAME, Config)}
 	) || _ <- lists:seq(1, 8)],
 	_ = [begin
 		{response, nofin, 200, _} = gun_pool:await(StreamRef),
@@ -271,7 +339,7 @@ kill_restart_h1(Config) ->
 	gun_pool:await_up(ManagerPid),
 	Streams2 = [{async, _} = gun_pool:get("/",
 		#{<<"host">> => Authority},
-		#{scope => ?FUNCTION_NAME}
+		#{scope => scope(?FUNCTION_NAME, Config)}
 	) || _ <- lists:seq(1, 8)],
 	_ = [begin
 		{response, nofin, 200, _} = gun_pool:await(StreamRef),
@@ -282,15 +350,17 @@ kill_restart_h2(Config) ->
 	doc("Confirm the Gun process is restarted and the pool operational "
 		"after an HTTP/2 Gun process has crashed."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http2]},
-		scope => ?FUNCTION_NAME
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy
 	}),
 	gun_pool:await_up(ManagerPid),
 	Streams1 = [{async, _} = gun_pool:get("/",
 		#{<<"host">> => Authority},
-		#{scope => ?FUNCTION_NAME}
+		#{scope => scope(?FUNCTION_NAME, Config)}
 	) || _ <- lists:seq(1, 800)],
 	_ = [begin
 		{response, nofin, 200, _} = gun_pool:await(StreamRef),
@@ -306,7 +376,7 @@ kill_restart_h2(Config) ->
 	gun_pool:await_up(ManagerPid),
 	Streams2 = [{async, _} = gun_pool:get("/",
 		#{<<"host">> => Authority},
-		#{scope => ?FUNCTION_NAME}
+		#{scope => scope(?FUNCTION_NAME, Config)}
 	) || _ <- lists:seq(1, 800)],
 	_ = [begin
 		{response, nofin, 200, _} = gun_pool:await(StreamRef),
@@ -315,17 +385,19 @@ kill_restart_h2(Config) ->
 
 %% @todo kill_restart_ws
 
-reconnect_h1(_) ->
+reconnect_h1(Config) ->
 	doc("Confirm the Gun process reconnects automatically for HTTP/1.1 connections."),
+	Strategy = config(selection_strategy, Config),
+	Listener = listener_name(?FUNCTION_NAME, Config),
 	ProtoOpts = do_proto_opts(),
-	{ok, _} = cowboy:start_clear(?FUNCTION_NAME, [], ProtoOpts#{
-		idle_timeout => 500,
-		scope => ?FUNCTION_NAME
+	{ok, _} = cowboy:start_clear(Listener, [], ProtoOpts#{
+		idle_timeout => 500
 	}),
-	Port = ranch:get_port(?FUNCTION_NAME),
+	Port = ranch:get_port(Listener),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
-		conn_opts => #{protocols => [http]}
+		conn_opts => #{protocols => [http]},
+		selection_strategy => Strategy
 	}),
 	gun_pool:await_up(ManagerPid),
 	Streams1 = [{async, _} = gun_pool:get("/", #{<<"host">> => Authority}) || _ <- lists:seq(1, 8)],
@@ -346,15 +418,17 @@ reconnect_h1(_) ->
 reconnect_h2(Config) ->
 	doc("Confirm the Gun process reconnects automatically for HTTP/2 connections."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	Authority = ["localhost:", integer_to_binary(Port)],
 	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
 		conn_opts => #{protocols => [http2]},
-		scope => ?FUNCTION_NAME
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy
 	}),
 	gun_pool:await_up(ManagerPid),
 	Streams1 = [{async, _} = gun_pool:get("/",
 		#{<<"host">> => Authority},
-		#{scope => ?FUNCTION_NAME}
+		#{scope => scope(?FUNCTION_NAME, Config)}
 	) || _ <- lists:seq(1, 800)],
 	_ = [begin
 		{response, nofin, 200, _} = gun_pool:await(StreamRef),
@@ -366,7 +440,7 @@ reconnect_h2(Config) ->
 	gun_pool:await_up(ManagerPid),
 	Streams2 = [{async, _} = gun_pool:get("/",
 		#{<<"host">> => Authority},
-		#{scope => ?FUNCTION_NAME}
+		#{scope => scope(?FUNCTION_NAME, Config)}
 	) || _ <- lists:seq(1, 800)],
 	_ = [begin
 		{response, nofin, 200, _} = gun_pool:await(StreamRef),
@@ -378,9 +452,13 @@ reconnect_h2(Config) ->
 stop_pool(Config) ->
 	doc("Confirm the pool can be stopped."),
 	Port = config(port, Config),
-	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{scope => ?FUNCTION_NAME}),
+	Strategy = config(selection_strategy, Config),
+	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy
+	}),
 	gun_pool:await_up(ManagerPid),
-	gun_pool:stop_pool("localhost", Port, #{scope => ?FUNCTION_NAME}).
+	gun_pool:stop_pool("localhost", Port, #{scope => scope(?FUNCTION_NAME, Config)}).
 
 degraded_configuration_error(Config) ->
 	case os:type() of
@@ -394,10 +472,12 @@ do_degraded_configuration_error(Config) ->
 	doc("Confirm the pool ends up in a degraded state "
 		"when connection is impossible because of bad configuration."),
 	Port = config(port, Config),
+	Strategy = config(selection_strategy, Config),
 	%% We attempt to connect to an unreachable IP.
 	{ok, ManagerPid} = gun_pool:start_pool({20, 20, 20, 1}, Port, #{
 		conn_opts => #{tcp_opts => [{ip, {127, 0, 0, 1}}]},
-		scope => ?FUNCTION_NAME,
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => Strategy,
 		size => 1
 	}),
 	%% Wait for the lookup/connect to fail.
@@ -405,4 +485,33 @@ do_degraded_configuration_error(Config) ->
 	{degraded, #{conns := Conns}} = gun_pool:info(ManagerPid),
 	true = Conns =:= #{},
 	%% We can stop the pool even if degraded.
-	gun_pool:stop_pool({20, 20, 20, 1}, Port, #{scope => ?FUNCTION_NAME}).
+	gun_pool:stop_pool({20, 20, 20, 1}, Port, #{scope => scope(?FUNCTION_NAME, Config)}).
+
+least_loaded_routing(Config) ->
+	doc("Confirm the least_loaded strategy always routes to the connection "
+		"with the fewest active streams."),
+	Port = config(port, Config),
+	Authority = ["localhost:", integer_to_binary(Port)],
+	{ok, ManagerPid} = gun_pool:start_pool("localhost", Port, #{
+		conn_opts => #{protocols => [http2]},
+		scope => scope(?FUNCTION_NAME, Config),
+		selection_strategy => least_loaded,
+		size => 2
+	}),
+	gun_pool:await_up(ManagerPid),
+	%% Occupy one connection with a slow request.
+	{async, {BusyConn, _}} = gun_pool:get("/delay",
+		#{<<"host">> => Authority}, #{scope => scope(?FUNCTION_NAME, Config)}),
+	%% Wait for the stream count cast to reach the manager.
+	timer:sleep(100),
+	%% Send requests one at a time and await each before the next.
+	%% This keeps the idle connection at 0-1 streams, always below the
+	%% busy connection, so least_loaded must consistently pick it.
+	%% With random selection this would pass with probability ~0.1%.
+	_ = [begin
+		{async, {ConnPid, _} = PoolStreamRef} = gun_pool:get("/",
+			#{<<"host">> => Authority}, #{scope => scope(?FUNCTION_NAME, Config)}),
+		true = ConnPid =/= BusyConn,
+		{response, nofin, 200, _} = gun_pool:await(PoolStreamRef),
+		{ok, <<"Hello world!">>} = gun_pool:await_body(PoolStreamRef)
+	end || _ <- lists:seq(1, 10)].


### PR DESCRIPTION
## Background

The current lookup strategy (designed random in this PR) has insufficient performance with larger pools, leading to unrecoverable pool collapse. This forces us to keep pools smaller.

## Changes

This PR allows us to configure a lookup strategy choosing between random (current implementation) and least loaded - which keeps a gb_tree that can be traversed starting from least busy connection. This gives as a much quicker lookup.

## Testing

All pool tests are run with both versions of the lookup strategy. Additionally, the least loaded strategy has a test making sure that the less busy connection is always chosen.