### PR TITLE
Reactivate socket  when chunk response exhausts flow window

### DIFF
--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -208,15 +208,15 @@ handle(Data, State=#http_state{in=body_chunked, in_state=InState, buffer=Buffer,
 					{fin, EvHandlerState1}
 			end,
 			%% I suppose it doesn't hurt to append an empty binary.
-			%% We ignore the active command because the stream ended.
-			[{state, State1}|_] = send_data(<<>>, State, IsFin),
+			[{state, State1}, ActiveCommand] = send_data(<<>>, State, IsFin),
 			case {HasTrailers, Conn} of
 				{trailers, _} ->
 					handle(Rest, State1#http_state{buffer = <<>>, in=body_trailer},
 						CookieStore, EvHandler, EvHandlerState);
 				{no_trailers, keepalive} ->
-					handle(Rest, end_stream(State1#http_state{buffer= <<>>}),
-						CookieStore, EvHandler, EvHandlerState);
+					prepend_command(ActiveCommand,
+						handle(Rest, end_stream(State1#http_state{buffer= <<>>}),
+						CookieStore, EvHandler, EvHandlerState));
 				{no_trailers, close} ->
 					{[{state, end_stream(State1)}, close], CookieStore, EvHandlerState}
 			end;
@@ -232,15 +232,15 @@ handle(Data, State=#http_state{in=body_chunked, in_state=InState, buffer=Buffer,
 					}, EvHandlerState0),
 					{fin, EvHandlerState1}
 			end,
-			%% We ignore the active command because the stream ended.
-			[{state, State1}|_] = send_data(Data2, State, IsFin),
+			[{state, State1}, ActiveCommand] = send_data(Data2, State, IsFin),
 			case {HasTrailers, Conn} of
 				{trailers, _} ->
 					handle(Rest, State1#http_state{buffer = <<>>, in=body_trailer},
 						CookieStore, EvHandler, EvHandlerState);
 				{no_trailers, keepalive} ->
-					handle(Rest, end_stream(State1#http_state{buffer= <<>>}),
-						CookieStore, EvHandler, EvHandlerState);
+					prepend_command(ActiveCommand,
+						handle(Rest, end_stream(State1#http_state{buffer= <<>>}),
+						CookieStore, EvHandler, EvHandlerState));
 				{no_trailers, close} ->
 					{[{state, end_stream(State1)}, close], CookieStore, EvHandlerState}
 			end
@@ -275,8 +275,9 @@ handle(Data, State=#http_state{opts=Opts, in=body_trailer,
 			EvHandlerState = EvHandler:response_end(ResponseEvent, EvHandlerState1),
 			case Conn of
 				keepalive ->
-					handle(Rest, end_stream(State#http_state{buffer= <<>>}),
-						CookieStore, EvHandler, EvHandlerState);
+					prepend_command({active, true},
+						handle(Rest, end_stream(State#http_state{buffer= <<>>}),
+						CookieStore, EvHandler, EvHandlerState));
 				close ->
 					{[{state, end_stream(State)}, close], CookieStore, EvHandlerState}
 			end
@@ -293,29 +294,29 @@ handle(Data, State=#http_state{in={body, Length}, connection=Conn,
 				CookieStore, EvHandlerState0};
 		%% Stream finished, no rest.
 		DataSize =:= Length ->
-			%% We ignore the active command because the stream ended.
-			[{state, State1}|_] = send_data(Data, State, fin),
+			[{state, State1}, ActiveCommand] = send_data(Data, State, fin),
 			EvHandlerState = EvHandler:response_end(#{
 				stream_ref => stream_ref(State, StreamRef),
 				reply_to => ReplyTo
 			}, EvHandlerState0),
 			case Conn of
 				keepalive ->
-					{[{state, end_stream(State1)}, {active, true}], CookieStore, EvHandlerState};
+					{[{state, end_stream(State1)}, ActiveCommand], CookieStore, EvHandlerState};
 				close ->
 					{[{state, end_stream(State1)}, close], CookieStore, EvHandlerState}
 			end;
 		%% Stream finished, rest.
 		true ->
 			<< Body:Length/binary, Rest/bits >> = Data,
-			%% We ignore the active command because the stream ended.
-			[{state, State1}|_] = send_data(Body, State, fin),
+			[{state, State1}, ActiveCommand] = send_data(Body, State, fin),
 			EvHandlerState = EvHandler:response_end(#{
 				stream_ref => stream_ref(State1, StreamRef),
 				reply_to => ReplyTo
 			}, EvHandlerState0),
 			case Conn of
-				keepalive -> handle(Rest, end_stream(State1), CookieStore, EvHandler, EvHandlerState);
+				keepalive ->
+					prepend_command(ActiveCommand,
+						handle(Rest, end_stream(State1), CookieStore, EvHandler, EvHandlerState));
 				close -> {[{state, end_stream(State1)}, close], CookieStore, EvHandlerState}
 			end
 	end.
@@ -509,6 +510,13 @@ handle_response(Rest, State=#http_state{version=ClientVersion, opts=Opts, connec
 				CookieStore, EvHandler, EvHandlerState3)
 	end.
 
+%% Commands from parsing the remaining buffer come after the prepended
+%% command and may override it.
+prepend_command(Command, {Commands, CookieStore, EvHandlerState}) when is_list(Commands) ->
+	{[Command|Commands], CookieStore, EvHandlerState};
+prepend_command(Command, {OneCommand, CookieStore, EvHandlerState}) ->
+	{[Command, OneCommand], CookieStore, EvHandlerState}.
+
 %% The state must be first in order to retrieve it when the stream ended.
 send_data(<<>>, State, nofin) ->
 	[{state, State}, {active, true}];
@@ -522,7 +530,11 @@ send_data(Data, State=#http_state{streams=[Stream=#stream{
 	end,
 	[
 		{state, State#http_state{streams=[Stream#stream{flow=Flow, handler_state=Handlers}|Tail]}},
-		{active, Flow > 0}
+		%% When the response ends, socket must be reactivated regardless of
+		%% the flow window, otherwise nothing is left to make it active
+		%% again, and responses to subsequent requests on a keepalive
+		%% connection would never be read.
+		{active, (Flow > 0) orelse (IsFin =:= fin)}
 	];
 send_data(_, State, _) ->
 	[{state, State}, {active, true}].

--- a/test/flow_SUITE.erl
+++ b/test/flow_SUITE.erl
@@ -126,6 +126,62 @@ flow_http(_) ->
 		cowboy:stop_listener(?FUNCTION_NAME)
 	end.
 
+flow_http_body_end_keepalive(_) ->
+	doc("Chunked response body ending with exhausted flow window HTTP/1.1"),
+	do_flow_http_body_end_keepalive(no_trailers).
+
+flow_http_trailers_keepalive(_) ->
+	doc("Chunked response body with trailers with exhausted flow window HTTP/1.1"),
+	do_flow_http_body_end_keepalive(trailers).
+
+do_flow_http_body_end_keepalive(HasTrailers) ->
+	{ok, _OriginPid, Port} = gun_test:init_origin(tcp, http,
+		fun(_, _, Socket, Transport) ->
+			chunked_origin(Socket, Transport, HasTrailers)
+		end),
+	{ok, ConnPid} = gun:open("localhost", Port),
+	{ok, http} = gun:await_up(ConnPid),
+	ok = do_flow2_requests(ConnPid, 50),
+	gun:close(ConnPid).
+
+chunked_origin(Socket, Transport, HasTrailers) ->
+	case Transport:recv(Socket, 0, 5000) of
+		{ok, _Req} ->
+			ok = Transport:send(Socket,
+				"HTTP/1.1 200 OK\r\n"
+				"transfer-encoding: chunked\r\n"
+				"\r\n"),
+			Chunk = ["1000\r\n", binary:copy(<<0>>, 16#1000), "\r\n"],
+			[Transport:send(Socket, Chunk) || _ <- lists:seq(1, 25)],
+			MaybeTrailers = case HasTrailers of
+				trailers -> "0\r\nexpires: 0\r\n\r\n";
+				no_trailers -> "0\r\n\r\n"
+			end,
+			Transport:send(Socket, MaybeTrailers),
+			chunked_origin(Socket, Transport, HasTrailers);
+		{error, _} ->
+			ok
+	end.
+
+do_flow2_requests(_, 0) ->
+	ok;
+do_flow2_requests(ConnPid, N) ->
+	StreamRef = gun:get(ConnPid, "/", [], #{flow => 2}),
+	{response, nofin, 200, _} = gun:await(ConnPid, StreamRef, 2000),
+	ok = consume_flow_body(ConnPid, StreamRef),
+	do_flow2_requests(ConnPid, N - 1).
+
+consume_flow_body(ConnPid, StreamRef) ->
+	case gun:await(ConnPid, StreamRef, 2000) of
+		{data, nofin, _} ->
+			gun:update_flow(ConnPid, StreamRef, 1),
+			consume_flow_body(ConnPid, StreamRef);
+		{data, fin, _} ->
+			ok;
+		{trailers, _} ->
+			ok
+	end.
+
 flow_http2(_) ->
 	doc("Confirm flow control works as intended for HTTP/2."),
 	{ok, _} = cowboy:start_clear(?FUNCTION_NAME, [], #{env => #{


### PR DESCRIPTION
Previously, with a flow window the final body message in a response can exhaust the window just when the stream ended. The socket then stayed passive. Any request issued next on the keepalive connection never gets its response read.

To fix it, make `send_data` emit `{active, (Flow > 0) orelse (IsFin =:= fin)}` so the message ending a stream reactivates the socket regardless of the flow window. End of stream call sites used to ignore send_data's active command (the content-length path replaced it with a hand-written {active, true}) but they now propagate it instead. The trailers path ends without a send_data call, so it reactivates the socket explicitly.

For tests use many sequential requests with flow > 1 on one connection against an origin streaming chunked bodies, with and without trailers.