### PR TITLE
HTTP/1: End stream before closing when a response ends with its headers

### DIFF
--- a/src/gun_http.erl
+++ b/src/gun_http.erl
@@ -483,7 +483,8 @@ handle_response(Rest, State=#http_state{version=ClientVersion, opts=Opts, connec
 	%% We always reset in_state even if not chunked.
 	if
 		IsFin =:= fin, Conn2 =:= close ->
-			{close, CookieStore, EvHandlerState3};
+			{[{state, end_stream(State#http_state{connection=Conn2})}, close],
+				CookieStore, EvHandlerState3};
 		IsFin =:= fin ->
 			end_keepalive_stream(Rest, State#http_state{in=In,
 				in_state={0, 0}, connection=Conn2,

--- a/test/gun_SUITE.erl
+++ b/test/gun_SUITE.erl
@@ -299,6 +299,38 @@ killed_streams_http(_) ->
 			gun:close(ConnPid)
 	end.
 
+killed_streams_http_no_body(_) ->
+	doc("Ensure completed responses without a body and with a connection: close "
+		"are not considered killed streams."),
+	{ok, _, OriginPort} = init_origin(tcp, http,
+		fun (_, _, ClientSocket, ClientTransport) ->
+			{ok, _} = ClientTransport:recv(ClientSocket, 0, 1000),
+			ClientTransport:send(ClientSocket,
+				"HTTP/1.1 200 OK\r\n"
+				"connection: close\r\n"
+				"content-length: 0\r\n"
+				"\r\n"
+			)
+		end),
+	{ok, ConnPid} = gun:open("localhost", OriginPort),
+	{ok, http} = gun:await_up(ConnPid),
+	StreamRef = gun:get(ConnPid, "/"),
+	{response, fin, 200, _} = gun:await(ConnPid, StreamRef),
+	receive
+		{gun_down, ConnPid, http, normal, KilledStreams} ->
+			[] = KilledStreams
+	after 1000 ->
+		error(timeout)
+	end,
+	%% The completed stream must not receive an error either.
+	receive
+		{gun_error, ConnPid, StreamRef, Reason} ->
+			error({unexpected_error, Reason})
+	after 0 ->
+		ok
+	end,
+	gun:close(ConnPid).
+
 list_header_name(_) ->
 	doc("Header names may be given as list."),
 	{ok, OriginPid, OriginPort} = init_origin(tcp, http),


### PR DESCRIPTION
When an HTTP/1.1 response asks for the connection to be closed and has no body (for example a 204, a 304, or a `content-length: 0` response), gun issued the `close` command without removing the completed stream from the state first. The stream was therefore still around when the connection was torn down, so its owner received a spurious `gun_error` with reason `{closed, normal}` and the stream ref was listed in the `killed_streams` element of the `gun_down` message, even though the response had completed successfully. We can use the `end_stream/1` helper to fix this behavior.